### PR TITLE
Feat/7/order feat(payment): 토스페이먼츠 결제 API 연동 및 컨트롤러 구현

### DIFF
--- a/src/main/java/com/homesweet/homesweetback/domain/order/controller/PaymentController.java
+++ b/src/main/java/com/homesweet/homesweetback/domain/order/controller/PaymentController.java
@@ -1,0 +1,91 @@
+package com.homesweet.homesweetback.domain.order.controller;
+
+import com.homesweet.homesweetback.domain.order.dto.TossPaymentCancelRequest;
+import com.homesweet.homesweetback.domain.order.dto.TossPaymentConfirmRequest;
+import com.homesweet.homesweetback.domain.order.service.TossPaymentsService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+/**
+ * 토스페이먼츠 결제 API 컨트롤러
+ * 
+ * 결제 흐름:
+ * 1. 클라이언트에서 토스 결제 위젯으로 결제 요청
+ * 2. 결제 완료 후 successUrl로 리다이렉트되면서 paymentKey, orderId, amount 전달
+ * 3. POST /api/v1/payments/confirm 호출하여 결제 승인
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/payments")
+@RequiredArgsConstructor
+public class PaymentController {
+
+    private final TossPaymentsService tossPaymentsService;
+
+    /**
+     * 결제 승인 API
+     * 프론트엔드에서 토스 결제창 완료 후 받은 paymentKey, orderId, amount로 최종 결제 승인
+     * 
+     * @param request 결제 승인 요청 (paymentKey, orderId, amount)
+     * @return 토스페이먼츠 결제 승인 응답
+     */
+    @PostMapping("/confirm")
+    public ResponseEntity<Map<String, Object>> confirmPayment(
+            @RequestBody TossPaymentConfirmRequest request) {
+        log.info("결제 승인 API 호출: orderId={}, amount={}", request.getOrderId(), request.getAmount());
+
+        Map<String, Object> response = tossPaymentsService.confirmPayment(request);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 결제 취소 API
+     * 
+     * @param paymentKey 취소할 결제의 paymentKey
+     * @param request    취소 사유 및 부분 취소 금액 (선택)
+     * @return 토스페이먼츠 결제 취소 응답
+     */
+    @PostMapping("/{paymentKey}/cancel")
+    public ResponseEntity<Map<String, Object>> cancelPayment(
+            @PathVariable String paymentKey,
+            @RequestBody TossPaymentCancelRequest request) {
+        log.info("결제 취소 API 호출: paymentKey={}, reason={}", paymentKey, request.getCancelReason());
+
+        Map<String, Object> response = tossPaymentsService.cancelPayment(paymentKey, request);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * paymentKey로 결제 조회 API
+     * 
+     * @param paymentKey 조회할 결제의 paymentKey
+     * @return 토스페이먼츠 결제 정보
+     */
+    @GetMapping("/{paymentKey}")
+    public ResponseEntity<Map<String, Object>> getPaymentByPaymentKey(
+            @PathVariable String paymentKey) {
+        log.info("결제 조회 API 호출: paymentKey={}", paymentKey);
+
+        Map<String, Object> response = tossPaymentsService.getPaymentByPaymentKey(paymentKey);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * orderId로 결제 조회 API
+     * 
+     * @param orderId 조회할 주문의 orderId
+     * @return 토스페이먼츠 결제 정보
+     */
+    @GetMapping("/orders/{orderId}")
+    public ResponseEntity<Map<String, Object>> getPaymentByOrderId(
+            @PathVariable String orderId) {
+        log.info("주문ID로 결제 조회 API 호출: orderId={}", orderId);
+
+        Map<String, Object> response = tossPaymentsService.getPaymentByOrderId(orderId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/homesweet/homesweetback/domain/order/dto/TossPaymentCancelRequest.java
+++ b/src/main/java/com/homesweet/homesweetback/domain/order/dto/TossPaymentCancelRequest.java
@@ -1,13 +1,17 @@
 package com.homesweet.homesweetback.domain.order.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /**
  * 토스페이먼츠 결제 취소 요청 DTO
  */
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class TossPaymentCancelRequest {
 
     private String cancelReason;

--- a/src/main/java/com/homesweet/homesweetback/domain/order/dto/TossPaymentConfirmRequest.java
+++ b/src/main/java/com/homesweet/homesweetback/domain/order/dto/TossPaymentConfirmRequest.java
@@ -1,13 +1,17 @@
 package com.homesweet.homesweetback.domain.order.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /**
  * 토스페이먼츠 결제 승인 요청 DTO
  */
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class TossPaymentConfirmRequest {
 
     private String paymentKey;


### PR DESCRIPTION
## 구현 내용
토스페이먼츠 API와 연동하여 결제 승인/취소/조회 기능 구현

### 구현된 API 엔드포인트
| POST | `/api/v1/payments/confirm` | 결제 승인 |
| POST | `/api/v1/payments/{paymentKey}/cancel` | 결제 취소 |
| GET | `/api/v1/payments/{paymentKey}` | paymentKey로 조회 |
| GET | `/api/v1/payments/orders/{orderId}` | orderId로 조회 |

### 주요 변경사항
- **CircuitBreaker**: 토스 API 장애 시 빠른 실패 처리
- **Retry**: 일시적 네트워크 오류 시 최대 3회 재시도
- **Basic Auth**: 토스 API 인증 (시크릿키 Base64 인코딩)

## 테스트 완료 사항
<!-- 테스트한 항목에 체크(x)해주세요 -->
- [x] 단위 테스트
- [x] 통합 테스트
- [ ] API 테스트 (Swagger/Postman 등)
- [ ] 기타 테스트

## 스크린샷
<!-- 필요한 경우 관련 스크린샷을 첨부해주세요 -->

## 관련 이슈
<!-- 관련 이슈를 연결하세요. 이슈가 자동으로 닫히게 하려면 closes/fixes/resolves 키워드를 사용하세요 -->
closes #7 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added payment confirmation endpoint for order approval processing.
  * Added payment cancellation endpoint with reason and amount tracking.
  * Added payment detail retrieval endpoints by payment key and order ID.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->