### PR TITLE
feat(payment): 결제 승인 병목 완화 (Facade 분리 + Redis 멱등/락 + 타임아웃/풀 튜닝)

### DIFF
--- a/src/main/java/com/homesweet/homesweetback/common/config/AppConfig.java
+++ b/src/main/java/com/homesweet/homesweetback/common/config/AppConfig.java
@@ -1,15 +1,23 @@
 package com.homesweet.homesweetback.common.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
-@Configuration // 이 클래스가 Spring 설정 파일임을 알림
+@Configuration
 public class AppConfig {
 
-    @Bean // 이 메서드가 반환하는 객체를 Spring Bean으로 등록
-    public RestTemplate restTemplate() {
-        return new RestTemplate(); // RestTemplate 객체를 생성하여 반환
+    @Bean
+    public RestTemplate restTemplate(
+            @Value("${payments.toss.connect-timeout-ms:2000}") int connectTimeoutMs,
+            @Value("${payments.toss.read-timeout-ms:5000}") int readTimeoutMs
+    ) {
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(connectTimeoutMs);
+        requestFactory.setReadTimeout(readTimeoutMs);
+
+        return new RestTemplate(requestFactory);
     }
 }

--- a/src/main/java/com/homesweet/homesweetback/domain/order/service/MockTossPaymentsService.java
+++ b/src/main/java/com/homesweet/homesweetback/domain/order/service/MockTossPaymentsService.java
@@ -5,6 +5,7 @@ import com.homesweet.homesweetback.common.util.PaymentApiClient;
 import com.homesweet.homesweetback.domain.order.dto.TossPaymentCancelRequest;
 import com.homesweet.homesweetback.domain.order.dto.TossPaymentConfirmRequest;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
@@ -29,6 +30,7 @@ import java.util.UUID;
 @Service
 @Primary
 @Profile({"test", "dev", "local"})
+@ConditionalOnProperty(name = "payments.toss.mock.enabled", havingValue = "true")
 public class MockTossPaymentsService extends TossPaymentsService {
 
     // 부모 클래스의 필드를 주입받지만 Mock에서는 사용하지 않음
@@ -36,7 +38,7 @@ public class MockTossPaymentsService extends TossPaymentsService {
                                    PaymentApiClient paymentApiClient, 
                                    RestTemplate restTemplate) {
         super(tossPaymentsConfig, paymentApiClient, restTemplate);
-        log.info("🎭 Mock TossPaymentsService 활성화 - 실제 API 호출 없이 테스트합니다");
+        log.info("Mock TossPaymentsService enabled");
     }
 
     @Override

--- a/src/main/java/com/homesweet/homesweetback/domain/order/service/PaymentRedisGuardService.java
+++ b/src/main/java/com/homesweet/homesweetback/domain/order/service/PaymentRedisGuardService.java
@@ -1,0 +1,79 @@
+package com.homesweet.homesweetback.domain.order.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PaymentRedisGuardService {
+
+    private static final String IDEMPOTENCY_KEY_PREFIX = "payment:idempotency:";
+    private static final String ORDER_LOCK_KEY_PREFIX = "payment:lock:order:";
+
+    private static final Duration IDEMPOTENCY_TTL = Duration.ofSeconds(30);
+    private static final Duration ORDER_LOCK_TTL = Duration.ofSeconds(30);
+
+    private static final DefaultRedisScript<Long> RELEASE_LOCK_SCRIPT;
+
+    static {
+        RELEASE_LOCK_SCRIPT = new DefaultRedisScript<>();
+        RELEASE_LOCK_SCRIPT.setScriptText(
+                "if redis.call('get', KEYS[1]) == ARGV[1] then " +
+                        "return redis.call('del', KEYS[1]) " +
+                        "else return 0 end");
+        RELEASE_LOCK_SCRIPT.setResultType(Long.class);
+    }
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    public boolean tryAcquireIdempotency(String paymentKey) {
+        String key = idempotencyKey(paymentKey);
+        Boolean acquired = stringRedisTemplate.opsForValue().setIfAbsent(key, "IN_PROGRESS", IDEMPOTENCY_TTL);
+        return Boolean.TRUE.equals(acquired);
+    }
+
+    public void markIdempotencyCompleted(String paymentKey) {
+        stringRedisTemplate.opsForValue().set(idempotencyKey(paymentKey), "DONE", IDEMPOTENCY_TTL);
+    }
+
+    public void clearIdempotency(String paymentKey) {
+        stringRedisTemplate.delete(idempotencyKey(paymentKey));
+    }
+
+    public String tryAcquireOrderLock(String orderId) {
+        String token = UUID.randomUUID().toString();
+        Boolean acquired = stringRedisTemplate.opsForValue().setIfAbsent(orderLockKey(orderId), token, ORDER_LOCK_TTL);
+        if (Boolean.TRUE.equals(acquired)) {
+            return token;
+        }
+        return null;
+    }
+
+    public void releaseOrderLock(String orderId, String token) {
+        if (token == null) {
+            return;
+        }
+
+        try {
+            stringRedisTemplate.execute(RELEASE_LOCK_SCRIPT, List.of(orderLockKey(orderId)), token);
+        } catch (Exception e) {
+            log.warn("Failed to release payment order lock. orderId={}", orderId, e);
+        }
+    }
+
+    private String idempotencyKey(String paymentKey) {
+        return IDEMPOTENCY_KEY_PREFIX + paymentKey;
+    }
+
+    private String orderLockKey(String orderId) {
+        return ORDER_LOCK_KEY_PREFIX + orderId;
+    }
+}

--- a/src/main/java/com/homesweet/homesweetback/domain/order/service/PaymentServiceImpl.java
+++ b/src/main/java/com/homesweet/homesweetback/domain/order/service/PaymentServiceImpl.java
@@ -1,189 +1,103 @@
 package com.homesweet.homesweetback.domain.order.service;
 
-import com.homesweet.homesweetback.common.exception.OrderNotFoundException;
-import com.homesweet.homesweetback.common.exception.PaymentMismatchException;
 import com.homesweet.homesweetback.domain.order.dto.PaymentResponse;
 import com.homesweet.homesweetback.domain.order.dto.TossPaymentCancelRequest;
 import com.homesweet.homesweetback.domain.order.dto.TossPaymentConfirmRequest;
-import com.homesweet.homesweetback.domain.order.entity.Order;
 import com.homesweet.homesweetback.domain.order.entity.Payment;
-import com.homesweet.homesweetback.domain.order.entity.PaymentStatus;
-import com.homesweet.homesweetback.domain.order.repository.OrderRepository;
 import com.homesweet.homesweetback.domain.order.repository.PaymentRepository;
-import com.homesweet.homesweetback.domain.product.cart.repository.jpa.CartJPARepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
-import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.Objects;
 
 /**
- * 결제 서비스 구현체
- * 토스페이먼츠 API 연동 및 결제 비즈니스 로직 처리
+ * Payment facade.
+ *
+ * confirmPayment:
+ * 1) acquire redis idempotency/order lock
+ * 2) call external Toss API without DB transaction
+ * 3) persist payment/order state in transactional service
  */
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class PaymentServiceImpl implements PaymentService {
 
     private final TossPaymentsService tossPaymentsService;
     private final PaymentRepository paymentRepository;
-    private final OrderRepository orderRepository;
-    private final CartJPARepository cartJPARepository;
+    private final PaymentTransactionalService paymentTransactionalService;
+    private final PaymentRedisGuardService paymentRedisGuardService;
 
-    /**
-     * 결제 승인 처리
-     * 토스페이먼츠 결제창 완료 후 successUrl에서 호출
-     *
-     * 토스페이먼츠 문서에 따른 처리:
-     * 1. orderId로 주문 조회
-     * 2. amount 검증 (클라이언트 금액 조작 방지)
-     * 3. 결제 승인 API 호출
-     * 4. Payment 엔티티 저장
-     * 5. Order 상태 변경
-     * 6. 장바구니에서 구매 완료된 상품 삭제
-     */
     @Override
-    @Transactional
     public PaymentResponse confirmPayment(Long userId, TossPaymentConfirmRequest request) {
-        log.info("결제 승인 처리 시작: userId={}, orderId={}, amount={}",
-                userId, request.getOrderId(), request.getAmount());
+        String paymentKey = request.getPaymentKey();
+        String orderId = request.getOrderId();
 
-        // 1. 주문 조회 (비관적 락으로 동시성 제어)
-        Order order = orderRepository.findByOrderNumberWithItemsForUpdate(request.getOrderId())
-                .orElseThrow(() -> new OrderNotFoundException("주문을 찾을 수 없습니다. orderId=" + request.getOrderId()));
+        log.info("Payment confirm started. userId={}, orderId={}, amount={}",
+                userId, orderId, request.getAmount());
 
-        // 권한 확인
-        if (!order.isOwner(userId)) {
-            throw new IllegalArgumentException("본인의 주문만 결제할 수 있습니다.");
+        if (!paymentRedisGuardService.tryAcquireIdempotency(paymentKey)) {
+            return paymentRepository.findByPaymentKey(paymentKey)
+                    .map(PaymentResponse::from)
+                    .orElseThrow(() -> new IllegalStateException("이미 처리 중인 결제 요청입니다."));
         }
 
-        // 중복 결제 승인 방지(동일 주문에 대한 재시도 처리)
-        Optional<Payment> existingPaymentOpt = paymentRepository.findByOrder(order);
-        if (existingPaymentOpt.isPresent()) {
-            Payment existing = existingPaymentOpt.get();
-
-            // 동일 paymentKey → 멱등 재시도, 기존 결과 반환
-            if (Objects.equals(existing.getPaymentKey(), request.getPaymentKey())) {
-                log.info("결제 승인 중복 요청 처리: paymentKey={}, orderId={}",
-                        request.getPaymentKey(), request.getOrderId());
-                return PaymentResponse.from(existing);
-            }
-
-            // 다른 paymentKey → 이미 처리된 주문에 대한 중복 결제 시도
-            throw new IllegalStateException("이미 결제 요청이 처리 중이거나 완료된 주문입니다.");
+        String orderLockToken = paymentRedisGuardService.tryAcquireOrderLock(orderId);
+        if (orderLockToken == null) {
+            paymentRedisGuardService.clearIdempotency(paymentKey);
+            throw new IllegalStateException("이미 해당 주문의 결제가 처리 중입니다.");
         }
 
-        // 2. 금액 검증 (토스페이먼츠 문서: 클라이언트 금액 조작 방지)
-        if (!order.getTotalAmount().equals(request.getAmount())) {
-            log.error("결제 금액 불일치: 주문금액={}, 요청금액={}",
-                    order.getTotalAmount(), request.getAmount());
-            throw new PaymentMismatchException("결제 금액이 주문 금액과 일치하지 않습니다.");
-        }
-
-        // 결제 가능한 주문 상태인지 확인
-        if (!order.isPending()) {
-            throw new IllegalStateException("결제 가능한 상태가 아닙니다.");
-        }
-
-        // 3. 토스페이먼츠 결제 승인 API 호출
-        Map<String, Object> tossResponse = tossPaymentsService.confirmPayment(request);
-
-        // 4. Payment 엔티티 생성 및 저장
+        boolean tossApproved = false;
         try {
-            Payment payment = Payment.builder()
-                    .order(order)
-                    .paymentKey(request.getPaymentKey())
-                    .tossOrderId(request.getOrderId())
-                    .status(PaymentStatus.READY)
-                    .amount(request.getAmount())
-                    .requestedAt(parseDateTime(tossResponse.get("requestedAt")))
-                    .build();
+            Map<String, Object> tossResponse = tossPaymentsService.confirmPayment(request);
+            tossApproved = true;
 
-            // 토스 응답에서 정보 추출하여 결제 완료 처리
-            String method = extractString(tossResponse, "method");
-            LocalDateTime approvedAt = parseDateTime(tossResponse.get("approvedAt"));
-            String receiptUrl = extractReceiptUrl(tossResponse);
+            PaymentResponse response = paymentTransactionalService.persistConfirmedPayment(userId, request, tossResponse);
+            paymentRedisGuardService.markIdempotencyCompleted(paymentKey);
 
-            payment.complete(method, approvedAt, receiptUrl);
-            paymentRepository.save(payment);
-
-            // 5. 주문 상태 변경
-            order.pay();
-            orderRepository.save(order);
-
-            // 6. 장바구니에서 구매 완료된 SKU 삭제
-            List<Long> purchasedSkuIds = order.getOrderItems().stream()
-                    .map(item -> item.getSku().getId())
-                    .toList();
-            cartJPARepository.deleteCartItemNative(userId, purchasedSkuIds);
-
-            log.info("결제 승인 완료: paymentKey={}, orderId={}", request.getPaymentKey(), order.getId());
-            return PaymentResponse.from(payment);
-
-        } catch (DataIntegrityViolationException e) {
-            // UNIQUE 제약 위반(중복 결제)만 선별 처리, 나머지 무결성 오류는 원본 전파
-            String message = e.getMostSpecificCause().getMessage();
-            if (message != null && message.contains("Duplicate entry")) {
-                log.warn("중복 결제 저장 감지 - 보상 취소 시도: paymentKey={}, orderId={}",
-                        request.getPaymentKey(), request.getOrderId());
-                cancelPaymentForCompensation(request.getPaymentKey());
-                throw new IllegalStateException("이미 결제 요청이 처리 중이거나 완료된 주문입니다.");
-            }
-            throw e;
+            log.info("Payment confirm completed. paymentKey={}, orderId={}", paymentKey, orderId);
+            return response;
 
         } catch (Exception e) {
-            // 토스 승인 성공 후 DB 저장 실패 시 보상 취소
-            log.error("결제 승인 후 DB 처리 실패 - 보상 취소 시도: paymentKey={}, orderId={}, error={}",
-                    request.getPaymentKey(), request.getOrderId(), e.getMessage());
-            cancelPaymentForCompensation(request.getPaymentKey());
+            paymentRedisGuardService.clearIdempotency(paymentKey);
+
+            if (tossApproved) {
+                cancelPaymentForCompensation(paymentKey);
+            }
             throw e;
+
+        } finally {
+            paymentRedisGuardService.releaseOrderLock(orderId, orderLockToken);
         }
     }
 
-    /**
-     * 보상 취소: 외부 승인 성공 후 내부 DB 처리 실패 시 토스 결제를 취소하여 상태 불일치 방지
-     */
     private void cancelPaymentForCompensation(String paymentKey) {
         try {
             TossPaymentCancelRequest cancelRequest = new TossPaymentCancelRequest("시스템 보상 취소: DB 처리 실패", null);
             tossPaymentsService.cancelPayment(paymentKey, cancelRequest);
-            log.info("보상 취소 성공: paymentKey={}", paymentKey);
+            log.info("Compensation cancel succeeded. paymentKey={}", paymentKey);
         } catch (Exception cancelEx) {
-            // 보상 취소마저 실패하면 수동 개입 필요 - 알림/모니터링 연동 권장
-            log.error("보상 취소 실패 - 수동 확인 필요: paymentKey={}, error={}",
-                    paymentKey, cancelEx.getMessage(), cancelEx);
+            log.error("Compensation cancel failed. paymentKey={}", paymentKey, cancelEx);
         }
     }
 
-    /**
-     * 결제 취소
-     */
     @Override
     @Transactional
     public PaymentResponse cancelPayment(Long userId, String paymentKey, TossPaymentCancelRequest request) {
-        log.info("결제 취소 처리 시작: userId={}, paymentKey={}", userId, paymentKey);
+        log.info("Payment cancel started. userId={}, paymentKey={}", userId, paymentKey);
 
         Payment payment = paymentRepository.findByPaymentKey(paymentKey)
                 .orElseThrow(() -> new IllegalArgumentException("결제 정보를 찾을 수 없습니다."));
 
-        // 권한 확인
         if (!payment.getOrder().isOwner(userId)) {
             throw new IllegalArgumentException("본인의 결제만 취소할 수 있습니다.");
         }
 
-        // 토스페이먼츠 취소 API 호출
         tossPaymentsService.cancelPayment(paymentKey, request);
 
-        // 결제 상태 변경
         if (request.getCancelAmount() != null && request.getCancelAmount() < payment.getAmount()) {
             payment.partialCancel();
         } else {
@@ -192,14 +106,11 @@ public class PaymentServiceImpl implements PaymentService {
         }
 
         paymentRepository.save(payment);
-        log.info("결제 취소 완료: paymentKey={}", paymentKey);
+        log.info("Payment cancel completed. paymentKey={}", paymentKey);
 
         return PaymentResponse.from(payment);
     }
 
-    /**
-     * 결제 조회
-     */
     @Override
     public PaymentResponse getPayment(Long userId, String paymentKey) {
         Payment payment = paymentRepository.findByPaymentKey(paymentKey)
@@ -210,35 +121,5 @@ public class PaymentServiceImpl implements PaymentService {
         }
 
         return PaymentResponse.from(payment);
-    }
-
-    // ===== Helper Methods =====
-
-    private String extractString(Map<String, Object> map, String key) {
-        Object value = map.get(key);
-        return value != null ? value.toString() : null;
-    }
-
-    private String extractReceiptUrl(Map<String, Object> tossResponse) {
-        Object receipt = tossResponse.get("receipt");
-        if (receipt instanceof Map) {
-            @SuppressWarnings("unchecked")
-            Map<String, Object> receiptMap = (Map<String, Object>) receipt;
-            Object url = receiptMap.get("url");
-            return url != null ? url.toString() : null;
-        }
-        return null;
-    }
-
-    private LocalDateTime parseDateTime(Object value) {
-        if (value == null) {
-            return null;
-        }
-        try {
-            return OffsetDateTime.parse(value.toString()).toLocalDateTime();
-        } catch (Exception e) {
-            log.warn("날짜 파싱 실패: {}", value);
-            return null;
-        }
     }
 }

--- a/src/main/java/com/homesweet/homesweetback/domain/order/service/PaymentTransactionalService.java
+++ b/src/main/java/com/homesweet/homesweetback/domain/order/service/PaymentTransactionalService.java
@@ -1,0 +1,114 @@
+package com.homesweet.homesweetback.domain.order.service;
+
+import com.homesweet.homesweetback.common.exception.OrderNotFoundException;
+import com.homesweet.homesweetback.common.exception.PaymentMismatchException;
+import com.homesweet.homesweetback.domain.order.dto.PaymentResponse;
+import com.homesweet.homesweetback.domain.order.dto.TossPaymentConfirmRequest;
+import com.homesweet.homesweetback.domain.order.entity.Order;
+import com.homesweet.homesweetback.domain.order.entity.Payment;
+import com.homesweet.homesweetback.domain.order.entity.PaymentStatus;
+import com.homesweet.homesweetback.domain.order.repository.OrderRepository;
+import com.homesweet.homesweetback.domain.order.repository.PaymentRepository;
+import com.homesweet.homesweetback.domain.product.cart.repository.jpa.CartJPARepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PaymentTransactionalService {
+
+    private final PaymentRepository paymentRepository;
+    private final OrderRepository orderRepository;
+    private final CartJPARepository cartJPARepository;
+
+    @Transactional
+    public PaymentResponse persistConfirmedPayment(Long userId, TossPaymentConfirmRequest request,
+                                                   Map<String, Object> tossResponse) {
+        Order order = orderRepository.findByOrderNumberWithItemsForUpdate(request.getOrderId())
+                .orElseThrow(() -> new OrderNotFoundException("주문을 찾을 수 없습니다. orderId=" + request.getOrderId()));
+
+        if (!order.isOwner(userId)) {
+            throw new IllegalArgumentException("본인의 주문만 결제할 수 있습니다.");
+        }
+
+        Optional<Payment> existingPaymentOpt = paymentRepository.findByOrder(order);
+        if (existingPaymentOpt.isPresent()) {
+            Payment existing = existingPaymentOpt.get();
+            if (Objects.equals(existing.getPaymentKey(), request.getPaymentKey())) {
+                return PaymentResponse.from(existing);
+            }
+            throw new IllegalStateException("이미 결제 요청이 처리 중이거나 완료된 주문입니다.");
+        }
+
+        if (!order.getTotalAmount().equals(request.getAmount())) {
+            throw new PaymentMismatchException("결제 금액이 주문 금액과 일치하지 않습니다.");
+        }
+
+        if (!order.isPending()) {
+            throw new IllegalStateException("결제 가능한 상태가 아닙니다.");
+        }
+
+        Payment payment = Payment.builder()
+                .order(order)
+                .paymentKey(request.getPaymentKey())
+                .tossOrderId(request.getOrderId())
+                .status(PaymentStatus.READY)
+                .amount(request.getAmount())
+                .requestedAt(parseDateTime(tossResponse.get("requestedAt")))
+                .build();
+
+        String method = extractString(tossResponse, "method");
+        LocalDateTime approvedAt = parseDateTime(tossResponse.get("approvedAt"));
+        String receiptUrl = extractReceiptUrl(tossResponse);
+
+        payment.complete(method, approvedAt, receiptUrl);
+        paymentRepository.save(payment);
+
+        order.pay();
+        orderRepository.save(order);
+
+        List<Long> purchasedSkuIds = order.getOrderItems().stream()
+                .map(item -> item.getSku().getId())
+                .toList();
+        cartJPARepository.deleteCartItemNative(userId, purchasedSkuIds);
+
+        return PaymentResponse.from(payment);
+    }
+
+    private String extractString(Map<String, Object> map, String key) {
+        Object value = map.get(key);
+        return value != null ? value.toString() : null;
+    }
+
+    private String extractReceiptUrl(Map<String, Object> tossResponse) {
+        Object receipt = tossResponse.get("receipt");
+        if (receipt instanceof Map<?, ?> receiptMap) {
+            Object url = receiptMap.get("url");
+            return url != null ? url.toString() : null;
+        }
+        return null;
+    }
+
+    private LocalDateTime parseDateTime(Object value) {
+        if (value == null) {
+            return null;
+        }
+        try {
+            return OffsetDateTime.parse(value.toString()).toLocalDateTime();
+        } catch (Exception e) {
+            log.warn("Failed to parse date time from payment response. value={}", value);
+            return null;
+        }
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -2,9 +2,9 @@ server:
   port: 8080
   tomcat:
     threads:
-      max: 500
-      min-spare: 50
-    accept-count: 2000 # OS 레벨 대기열 크기
+      max: 250
+      min-spare: 40
+    accept-count: 1000 # OS 레벨 대기열 크기
     max-connections: 10000
     connection-timeout: 20000
 
@@ -19,7 +19,9 @@ spring:
     username: user
     password: password
     hikari:
-      maximum-pool-size: 150
+      maximum-pool-size: 120
+      minimum-idle: 20
+      connection-timeout: 2000
 
   jpa:
     hibernate:
@@ -100,6 +102,10 @@ log:
 # 토스페이먼츠 설정
 payments:
   toss:
+    mock:
+      enabled: false
+    connect-timeout-ms: 2000
+    read-timeout-ms: 5000
     secretKey: ${TOSS_PAYMENTS_SECRET_KEY}
 
 management:
@@ -117,4 +123,3 @@ management:
     metrics:
       export:
         enabled: true
-

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -52,6 +52,10 @@ app:
 
 payments:
   toss:
+    mock:
+      enabled: true
+    connect-timeout-ms: 2000
+    read-timeout-ms: 5000
     secretKey: ${TOSS_PAYMENTS_SECRET_KEY:test_sk_dummy_key}
 
 search:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -87,6 +87,10 @@ app:
   # 토스 페이먼츠 시크릿 키
 payments:
   toss:
+    mock:
+      enabled: true
+    connect-timeout-ms: 2000
+    read-timeout-ms: 5000
     secretKey: ${TOSS_PAYMENTS_SECRET_KEY}
 
 search:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -75,14 +75,21 @@ management:
 retry:
   instances:
     toss-payments-retry: # 재시도 설정 이름
-      maxRetryAttempts: 3        # 최대 3번까지 시도 (최초 1회 + 재시도 2회)
-      waitDuration: 500ms        # 재시도 사이의 간격 (0.5초)
+      maxRetryAttempts: 2        # 최대 2번까지 시도 (최초 1회 + 재시도 1회)
+      waitDuration: 200ms        # 재시도 사이의 간격 (0.2초)
       retryExceptions:           # 재시도할 예외 타입 (모든 에러를 다 재시도하진 않음)
         - java.io.IOException    # 네트워크 연결 오류
         - org.springframework.web.client.ResourceAccessException # 타임아웃 등
         - java.net.ConnectException
       ignoreExceptions:
         - org.springframework.web.client.HttpClientErrorException
+
+payments:
+  toss:
+    mock:
+      enabled: false
+    connect-timeout-ms: 2000
+    read-timeout-ms: 5000
 
 # Community 도메인 설정
 community:

--- a/src/test/java/com/homesweet/homesweetback/domain/order/service/PaymentServiceTest.java
+++ b/src/test/java/com/homesweet/homesweetback/domain/order/service/PaymentServiceTest.java
@@ -3,6 +3,7 @@ package com.homesweet.homesweetback.domain.order.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -31,14 +32,10 @@ import com.homesweet.homesweetback.domain.order.dto.PaymentResponse;
 import com.homesweet.homesweetback.domain.order.dto.TossPaymentCancelRequest;
 import com.homesweet.homesweetback.domain.order.dto.TossPaymentConfirmRequest;
 import com.homesweet.homesweetback.domain.order.entity.Order;
-import com.homesweet.homesweetback.domain.order.entity.OrderItem;
 import com.homesweet.homesweetback.domain.order.entity.OrderStatus;
 import com.homesweet.homesweetback.domain.order.entity.Payment;
 import com.homesweet.homesweetback.domain.order.entity.PaymentStatus;
-import com.homesweet.homesweetback.domain.order.repository.OrderRepository;
 import com.homesweet.homesweetback.domain.order.repository.PaymentRepository;
-import com.homesweet.homesweetback.domain.product.cart.repository.jpa.CartJPARepository;
-import com.homesweet.homesweetback.domain.product.product.command.repository.jpa.entity.SkuEntity;
 
 /**
  * PaymentService 단위 테스트
@@ -65,10 +62,10 @@ class PaymentServiceTest {
     private PaymentRepository paymentRepository;
 
     @Mock
-    private OrderRepository orderRepository;
+    private PaymentTransactionalService paymentTransactionalService;
 
     @Mock
-    private CartJPARepository cartJPARepository;
+    private PaymentRedisGuardService paymentRedisGuardService;
 
     @InjectMocks
     private PaymentServiceImpl paymentService;
@@ -116,25 +113,11 @@ class PaymentServiceTest {
         @Test
         @DisplayName("결제 승인 성공")
         void confirmPayment_Success() {
-            // given
             Long userId = 1L;
             String orderNumber = "TEST-ORDER-001";
             Long amount = 100000L;
             String paymentKey = "test_payment_key_123";
-
-            User user = createTestUser(userId);
-            Order order = createTestOrder(1L, user, orderNumber, amount);
-
-            // OrderItem mock 설정
-            OrderItem orderItem = mock(OrderItem.class);
-            SkuEntity sku = mock(SkuEntity.class);
-            given(sku.getId()).willReturn(1L);
-            given(orderItem.getSku()).willReturn(sku);
-            given(order.getOrderItems()).willReturn(List.of(orderItem));
-
             TossPaymentConfirmRequest request = new TossPaymentConfirmRequest(paymentKey, orderNumber, amount);
-
-            // 토스 응답 mock
             Map<String, Object> tossResponse = Map.of(
                     "paymentKey", paymentKey,
                     "orderId", orderNumber,
@@ -143,26 +126,25 @@ class PaymentServiceTest {
                     "requestedAt", "2026-01-21T10:00:00+09:00",
                     "approvedAt", "2026-01-21T10:00:05+09:00"
             );
+            PaymentResponse expected = PaymentResponse.builder().paymentId(1L).paymentKey(paymentKey).build();
 
-            given(orderRepository.findByOrderNumberWithItemsForUpdate(orderNumber)).willReturn(Optional.of(order));
+            given(paymentRedisGuardService.tryAcquireIdempotency(paymentKey)).willReturn(true);
+            given(paymentRedisGuardService.tryAcquireOrderLock(orderNumber)).willReturn("lock-token");
             given(tossPaymentsService.confirmPayment(request)).willReturn(tossResponse);
-            given(paymentRepository.save(any(Payment.class))).willAnswer(inv -> inv.getArgument(0));
+            given(paymentTransactionalService.persistConfirmedPayment(userId, request, tossResponse)).willReturn(expected);
 
-            // when
             PaymentResponse response = paymentService.confirmPayment(userId, request);
 
-            // then
             assertThat(response).isNotNull();
-            verify(orderRepository, times(1)).findByOrderNumberWithItemsForUpdate(orderNumber);
             verify(tossPaymentsService, times(1)).confirmPayment(request);
-            verify(paymentRepository, times(1)).save(any(Payment.class));
-            verify(order, times(1)).pay();
+            verify(paymentTransactionalService, times(1)).persistConfirmedPayment(userId, request, tossResponse);
+            verify(paymentRedisGuardService, times(1)).markIdempotencyCompleted(paymentKey);
+            verify(paymentRedisGuardService, times(1)).releaseOrderLock(orderNumber, "lock-token");
         }
 
         @Test
         @DisplayName("결제 승인 중복 요청 - 기존 결제 재활용")
         void confirmPayment_Idempotent_ReturnExisting() {
-            // given
             Long userId = 1L;
             String orderNumber = "TEST-ORDER-001";
             Long amount = 100000L;
@@ -174,100 +156,94 @@ class PaymentServiceTest {
 
             TossPaymentConfirmRequest request = new TossPaymentConfirmRequest(paymentKey, orderNumber, amount);
 
-            given(orderRepository.findByOrderNumberWithItemsForUpdate(orderNumber)).willReturn(Optional.of(order));
-            given(paymentRepository.findByOrder(order)).willReturn(Optional.of(existingPayment));
+            given(paymentRedisGuardService.tryAcquireIdempotency(paymentKey)).willReturn(false);
+            given(paymentRepository.findByPaymentKey(paymentKey)).willReturn(Optional.of(existingPayment));
 
-            // when
             PaymentResponse response = paymentService.confirmPayment(userId, request);
 
-            // then
             assertThat(response).isNotNull();
             assertThat(response.getPaymentId()).isEqualTo(existingPayment.getId());
             verify(tossPaymentsService, never()).confirmPayment(request);
-            verify(paymentRepository, never()).save(any(Payment.class));
-            verify(order, never()).pay();
+            verify(paymentTransactionalService, never()).persistConfirmedPayment(any(), any(), any());
         }
 
         @Test
-        @DisplayName("결제 승인 실패 - 중복 결제키 충돌")
-        void confirmPayment_Fail_DuplicatePaymentKeyMismatch() {
-            // given
+        @DisplayName("결제 승인 실패 - 이미 처리 중인 요청")
+        void confirmPayment_Fail_AlreadyProcessing() {
             Long userId = 1L;
             String orderNumber = "TEST-ORDER-001";
             Long amount = 100000L;
-
-            User user = createTestUser(userId);
-            Order order = createTestOrder(1L, user, orderNumber, amount);
-            Payment existingPayment = createTestPayment(10L, order, "other_payment_key");
-
             TossPaymentConfirmRequest request = new TossPaymentConfirmRequest("test_payment_key_123", orderNumber, amount);
 
-            given(orderRepository.findByOrderNumberWithItemsForUpdate(orderNumber)).willReturn(Optional.of(order));
-            given(paymentRepository.findByOrder(order)).willReturn(Optional.of(existingPayment));
+            given(paymentRedisGuardService.tryAcquireIdempotency(request.getPaymentKey())).willReturn(false);
+            given(paymentRepository.findByPaymentKey(request.getPaymentKey())).willReturn(Optional.empty());
 
-            // when & then
             assertThatThrownBy(() -> paymentService.confirmPayment(userId, request))
                     .isInstanceOf(IllegalStateException.class)
-                    .hasMessageContaining("이미 결제 요청이 처리 중이거나 완료된 주문입니다.");
+                    .hasMessageContaining("이미 처리 중인 결제 요청입니다.");
         }
 
         @Test
-        @DisplayName("결제 승인 실패 - 주문 없음")
-        void confirmPayment_Fail_OrderNotFound() {
-            // given
+        @DisplayName("결제 승인 실패 - 주문 락 획득 실패")
+        void confirmPayment_Fail_OrderLockAcquire() {
             Long userId = 1L;
-            String orderNumber = "INVALID-ORDER";
-            TossPaymentConfirmRequest request = new TossPaymentConfirmRequest("key", orderNumber, 10000L);
+            String orderNumber = "TEST-ORDER-001";
+            TossPaymentConfirmRequest request = new TossPaymentConfirmRequest("key", orderNumber, 100000L);
 
-            given(orderRepository.findByOrderNumberWithItemsForUpdate(orderNumber)).willReturn(Optional.empty());
+            given(paymentRedisGuardService.tryAcquireIdempotency("key")).willReturn(true);
+            given(paymentRedisGuardService.tryAcquireOrderLock(orderNumber)).willReturn(null);
 
-            // when & then
             assertThatThrownBy(() -> paymentService.confirmPayment(userId, request))
-                    .isInstanceOf(OrderNotFoundException.class)
-                    .hasMessageContaining("주문을 찾을 수 없습니다");
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("이미 해당 주문의 결제가 처리 중입니다.");
+
+            verify(paymentRedisGuardService, times(1)).clearIdempotency("key");
+            verify(tossPaymentsService, never()).confirmPayment(any());
         }
 
         @Test
         @DisplayName("결제 승인 실패 - 금액 불일치")
         void confirmPayment_Fail_AmountMismatch() {
-            // given
             Long userId = 1L;
             String orderNumber = "TEST-ORDER-001";
-            User user = createTestUser(userId);
-            Order order = createTestOrder(1L, user, orderNumber, 100000L);
-
-            // 요청 금액이 주문 금액과 다름
             TossPaymentConfirmRequest request = new TossPaymentConfirmRequest("key", orderNumber, 50000L);
+            Map<String, Object> tossResponse = Map.of("status", "DONE");
 
-            given(orderRepository.findByOrderNumberWithItemsForUpdate(orderNumber)).willReturn(Optional.of(order));
+            given(paymentRedisGuardService.tryAcquireIdempotency("key")).willReturn(true);
+            given(paymentRedisGuardService.tryAcquireOrderLock(orderNumber)).willReturn("lock-token");
+            given(tossPaymentsService.confirmPayment(request)).willReturn(tossResponse);
+            given(paymentTransactionalService.persistConfirmedPayment(userId, request, tossResponse))
+                    .willThrow(new PaymentMismatchException("결제 금액이 주문 금액과 일치하지 않습니다."));
 
-            // when & then
             assertThatThrownBy(() -> paymentService.confirmPayment(userId, request))
                     .isInstanceOf(PaymentMismatchException.class)
-                    .hasMessageContaining("결제 금액이 주문 금액과 일치하지 않습니다");
+                    .hasMessageContaining("결제 금액이 주문 금액과 일치하지 않습니다.");
+
+            verify(tossPaymentsService, times(1)).cancelPayment(anyString(), any(TossPaymentCancelRequest.class));
+            verify(paymentRedisGuardService, times(1)).clearIdempotency("key");
+            verify(paymentRedisGuardService, times(1)).releaseOrderLock(orderNumber, "lock-token");
         }
 
         @Test
-        @DisplayName("결제 승인 실패 - 권한 없음 (다른 사용자의 주문)")
-        void confirmPayment_Fail_NotOwner() {
-            // given
+        @DisplayName("결제 승인 실패 - 주문 없음")
+        void confirmPayment_Fail_OrderNotFound() {
             Long userId = 1L;
-            Long otherUserId = 2L;
             String orderNumber = "TEST-ORDER-001";
-
-            User otherUser = createTestUser(otherUserId);
-            Order order = mock(Order.class);
-            given(order.getTotalAmount()).willReturn(100000L);
-            given(order.isOwner(userId)).willReturn(false);
-
             TossPaymentConfirmRequest request = new TossPaymentConfirmRequest("key", orderNumber, 100000L);
+            Map<String, Object> tossResponse = Map.of("status", "DONE");
 
-            given(orderRepository.findByOrderNumberWithItemsForUpdate(orderNumber)).willReturn(Optional.of(order));
+            given(paymentRedisGuardService.tryAcquireIdempotency("key")).willReturn(true);
+            given(paymentRedisGuardService.tryAcquireOrderLock(orderNumber)).willReturn("lock-token");
+            given(tossPaymentsService.confirmPayment(request)).willReturn(tossResponse);
+            given(paymentTransactionalService.persistConfirmedPayment(userId, request, tossResponse))
+                    .willThrow(new OrderNotFoundException("주문을 찾을 수 없습니다."));
 
-            // when & then
             assertThatThrownBy(() -> paymentService.confirmPayment(userId, request))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessageContaining("본인의 주문만 결제할 수 있습니다");
+                    .isInstanceOf(OrderNotFoundException.class);
+
+            verify(tossPaymentsService, times(1)).cancelPayment(anyString(), any(TossPaymentCancelRequest.class));
+            verify(paymentRedisGuardService, times(1)).clearIdempotency("key");
+            verify(paymentRedisGuardService, times(1)).releaseOrderLock(orderNumber, "lock-token");
         }
     }
 


### PR DESCRIPTION
feat(payment): 결제 승인 병목 완화 (Facade 분리 + Redis 멱등/락 + 타임아웃/풀 튜닝)

- confirmPayment 트랜잭션 분리 (Facade + PaymentTransactionalService)
- Redis 멱등키/주문 락 추가 (SET NX EX 30, Lua 기반 안전 unlock)
- Toss API RestTemplate connect/read timeout 설정
- dev Tomcat/Hikari 밸런스 조정 및 retry 설정 완화
- Mock Toss 활성화 조건을 프로퍼티(payments.toss.mock.enabled)로 전환
- PaymentServiceTest 구조 변경 및 회귀 테스트 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced payment processing with idempotency and distributed locking to prevent duplicate transactions.
  * Configurable connection and read timeout settings for payment service interactions (default: 2000ms connect, 5000ms read).
  * Mock payment service mode for testing environments.

* **Bug Fixes**
  * Improved payment reliability with automatic compensation on failure and better error recovery.

* **Chores**
  * Updated server and connection pool configurations for dev environment.
  * Adjusted retry policy settings for payment operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->