### PR TITLE
fix(order): 주문/결제 재고 일관성 보장

### DIFF
--- a/src/main/java/com/homesweet/homesweetback/domain/order/service/OrderServiceImpl.java
+++ b/src/main/java/com/homesweet/homesweetback/domain/order/service/OrderServiceImpl.java
@@ -1,6 +1,7 @@
 package com.homesweet.homesweetback.domain.order.service;
 
 import com.homesweet.homesweetback.common.exception.OrderNotFoundException;
+import com.homesweet.homesweetback.common.exception.StockInsufficientException;
 import com.homesweet.homesweetback.domain.auth.entity.User;
 import com.homesweet.homesweetback.domain.auth.repository.UserRepository;
 import com.homesweet.homesweetback.domain.order.dto.CreateOrderRequest;
@@ -18,11 +19,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import java.util.LinkedHashMap;
 
 /**
  * 주문 서비스 구현체
@@ -97,6 +99,27 @@ public class OrderServiceImpl implements OrderService {
             totalAmount += unitPrice * entry.getValue();
         }
 
+        // 재고 차감 (DB 원자적 UPDATE)
+        List<Map.Entry<Long, Integer>> deductedEntries = new ArrayList<>();
+        try {
+            for (Map.Entry<Long, Integer> entry : skuQuantitiesById.entrySet()) {
+                Long skuId = entry.getKey();
+                int quantity = entry.getValue();
+                int updatedRows = skuJPARepository.decreaseStock(skuId, (long) quantity);
+                if (updatedRows == 0) {
+                    throw new StockInsufficientException(
+                            "재고가 부족합니다. (SKU: " + skuId + ", 요청 수량: " + quantity + ")");
+                }
+                deductedEntries.add(entry);
+            }
+        } catch (StockInsufficientException e) {
+            // 일부만 차감 성공한 경우 복원
+            for (Map.Entry<Long, Integer> deducted : deductedEntries) {
+                skuJPARepository.increaseStock(deducted.getKey(), (long) deducted.getValue());
+            }
+            throw e;
+        }
+
         // 주문 생성
         String orderNumber = generateOrderNumber();
         Order order = Order.builder()
@@ -163,11 +186,12 @@ public class OrderServiceImpl implements OrderService {
 
     /**
      * 주문 취소 (결제 전 PENDING 상태에서만 가능)
+     * 취소 시 차감된 재고를 복원합니다.
      */
     @Override
     @Transactional
     public void cancelOrder(Long orderId, Long userId) {
-        Order order = orderRepository.findById(orderId)
+        Order order = orderRepository.findByIdWithItems(orderId)
                 .orElseThrow(() -> new OrderNotFoundException("주문을 찾을 수 없습니다. orderId=" + orderId));
 
         if (!order.isOwner(userId)) {
@@ -178,8 +202,21 @@ public class OrderServiceImpl implements OrderService {
             throw new IllegalStateException("결제 대기 상태의 주문만 취소할 수 있습니다.");
         }
 
+        // 재고 복원
+        restoreStock(order);
+
         order.cancel();
         log.info("주문 취소 완료: orderId={}", orderId);
+    }
+
+    /**
+     * 주문 항목의 재고를 복원합니다.
+     */
+    private void restoreStock(Order order) {
+        for (OrderItem item : order.getOrderItems()) {
+            skuJPARepository.increaseStock(item.getSku().getId(), item.getQuantity());
+            log.info("재고 복원: skuId={}, quantity={}", item.getSku().getId(), item.getQuantity());
+        }
     }
 
     /**

--- a/src/main/java/com/homesweet/homesweetback/domain/order/service/PaymentServiceImpl.java
+++ b/src/main/java/com/homesweet/homesweetback/domain/order/service/PaymentServiceImpl.java
@@ -3,8 +3,10 @@ package com.homesweet.homesweetback.domain.order.service;
 import com.homesweet.homesweetback.domain.order.dto.PaymentResponse;
 import com.homesweet.homesweetback.domain.order.dto.TossPaymentCancelRequest;
 import com.homesweet.homesweetback.domain.order.dto.TossPaymentConfirmRequest;
+import com.homesweet.homesweetback.domain.order.entity.OrderItem;
 import com.homesweet.homesweetback.domain.order.entity.Payment;
 import com.homesweet.homesweetback.domain.order.repository.PaymentRepository;
+import com.homesweet.homesweetback.domain.product.product.command.repository.jpa.SkuJPARepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -29,6 +31,7 @@ public class PaymentServiceImpl implements PaymentService {
     private final PaymentRepository paymentRepository;
     private final PaymentTransactionalService paymentTransactionalService;
     private final PaymentRedisGuardService paymentRedisGuardService;
+    private final SkuJPARepository skuJPARepository;
 
     @Override
     public PaymentResponse confirmPayment(Long userId, TossPaymentConfirmRequest request) {
@@ -103,6 +106,13 @@ public class PaymentServiceImpl implements PaymentService {
         } else {
             payment.cancel();
             payment.getOrder().cancel();
+
+            // 전체 취소 시 재고 복원
+            for (OrderItem item : payment.getOrder().getOrderItems()) {
+                skuJPARepository.increaseStock(item.getSku().getId(), item.getQuantity());
+                log.info("결제 취소 재고 복원: skuId={}, quantity={}",
+                        item.getSku().getId(), item.getQuantity());
+            }
         }
 
         paymentRepository.save(payment);

--- a/src/main/java/com/homesweet/homesweetback/domain/product/product/command/repository/jpa/SkuJPARepository.java
+++ b/src/main/java/com/homesweet/homesweetback/domain/product/product/command/repository/jpa/SkuJPARepository.java
@@ -2,12 +2,31 @@ package com.homesweet.homesweetback.domain.product.product.command.repository.jp
 
 import com.homesweet.homesweetback.domain.product.product.command.repository.jpa.entity.SkuEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface SkuJPARepository extends JpaRepository<SkuEntity, Long> {
+
     @Query("SELECT s FROM SkuEntity s JOIN FETCH s.product WHERE s.id IN :ids")
     List<SkuEntity> findAllByIdWithProduct(@Param("ids") List<Long> ids);
+
+    /**
+     * DB 레벨 원자적 재고 차감.
+     * stock_quantity >= quantity 조건으로 재고 부족 시 업데이트 0건 반환.
+     */
+    @Modifying
+    @Query("UPDATE SkuEntity s SET s.stockQuantity = s.stockQuantity - :quantity "
+            + "WHERE s.id = :skuId AND s.stockQuantity >= :quantity")
+    int decreaseStock(@Param("skuId") Long skuId, @Param("quantity") Long quantity);
+
+    /**
+     * DB 레벨 원자적 재고 복원.
+     */
+    @Modifying
+    @Query("UPDATE SkuEntity s SET s.stockQuantity = s.stockQuantity + :quantity "
+            + "WHERE s.id = :skuId")
+    int increaseStock(@Param("skuId") Long skuId, @Param("quantity") Long quantity);
 }


### PR DESCRIPTION
fix(order): 주문/결제 재고 일관성 보장

주문 생성 시 SKU 재고를 DB 원자적 UPDATE로 차감

재고 부족 시 예외 발생 및 부분 차감 롤백 처리

주문 취소/결제 전체 취소 시 주문 아이템 기준 재고 복원

SkuJPARepository에 decreaseStock/increaseStock 쿼리 추가



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved inventory management with atomic stock operations—orders now deduct stock as all-or-nothing transactions.

* **Bug Fixes**
  * Stock inventory now properly restored when orders or payments are cancelled.
  * Enhanced error handling for insufficient stock scenarios with detailed feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->