### PR TITLE
refactor(order): 주문 목록 조회 성능 개선 및 페이징 도입

### DIFF
--- a/k6/order-payment-load-test.js
+++ b/k6/order-payment-load-test.js
@@ -186,7 +186,7 @@ export function orderReadFlow(data) {
   const userId = randomUserId();
 
   group('내 주문 목록', () => {
-    const res = http.get(`${ORDER_API}?testUserId=${userId}`);
+    const res = http.get(`${ORDER_API}?testUserId=${userId}&page=0&size=20`);
     orderListLatency.add(res.timings.duration);
 
     const ok = check(res, { '목록 조회 200': (r) => r.status === 200 });

--- a/src/main/java/com/homesweet/homesweetback/domain/order/controller/OrderController.java
+++ b/src/main/java/com/homesweet/homesweetback/domain/order/controller/OrderController.java
@@ -80,11 +80,13 @@ public class OrderController {
     @GetMapping
     public ResponseEntity<List<OrderResponse>> getMyOrders(
             @RequestParam(required = false) Long testUserId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
             Authentication authentication) {
 
         Long userId = getUserId(testUserId, authentication);
-        log.info("주문 목록 조회 API 호출: userId={}", userId);
-        List<OrderResponse> orders = orderService.getMyOrders(userId);
+        log.info("주문 목록 조회 API 호출: userId={}, page={}, size={}", userId, page, size);
+        List<OrderResponse> orders = orderService.getMyOrders(userId, page, size);
         return ResponseEntity.ok(orders);
     }
 

--- a/src/main/java/com/homesweet/homesweetback/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/homesweet/homesweetback/domain/order/repository/OrderRepository.java
@@ -34,6 +34,18 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
             "ORDER BY o.createdAt DESC")
     List<Order> findByUserIdWithItemsAndProduct(@Param("userId") Long userId);
 
+    @Query("SELECT o.id FROM Order o " +
+            "WHERE o.user.id = :userId " +
+            "ORDER BY o.createdAt DESC")
+    List<Long> findIdsByUserId(@Param("userId") Long userId, Pageable pageable);
+
+    @Query("SELECT DISTINCT o FROM Order o " +
+            "LEFT JOIN FETCH o.orderItems oi " +
+            "LEFT JOIN FETCH oi.sku " +
+            "WHERE o.id IN :orderIds " +
+            "ORDER BY o.createdAt DESC")
+    List<Order> findByIdInWithItemsAndProduct(@Param("orderIds") List<Long> orderIds);
+
     @Query("SELECT DISTINCT o FROM Order o " +
             "LEFT JOIN FETCH o.orderItems oi " +
             "LEFT JOIN FETCH oi.sku " +

--- a/src/main/java/com/homesweet/homesweetback/domain/order/service/OrderService.java
+++ b/src/main/java/com/homesweet/homesweetback/domain/order/service/OrderService.java
@@ -33,9 +33,11 @@ public interface OrderService {
      * 내 주문 목록 조회
      *
      * @param userId 사용자 ID
+     * @param page 페이지 번호
+     * @param size 페이지 크기
      * @return 주문 목록
      */
-    List<OrderResponse> getMyOrders(Long userId);
+    List<OrderResponse> getMyOrders(Long userId, int page, int size);
 
     /**
      * 주문 취소 (결제 전 상태에서만 가능)

--- a/src/main/java/com/homesweet/homesweetback/domain/order/service/OrderServiceImpl.java
+++ b/src/main/java/com/homesweet/homesweetback/domain/order/service/OrderServiceImpl.java
@@ -17,6 +17,9 @@ import com.homesweet.homesweetback.domain.product.product.command.repository.jpa
 import com.homesweet.homesweetback.domain.product.product.command.repository.jpa.entity.SkuEntity;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,6 +46,8 @@ public class OrderServiceImpl implements OrderService {
     private static final int RECIPIENT_PHONE_MAX_LENGTH = 30;
     private static final int SHIPPING_ADDRESS_MAX_LENGTH = 500;
     private static final int SHIPPING_REQUEST_MAX_LENGTH = 500;
+    private static final int DEFAULT_ORDER_LIST_SIZE = 20;
+    private static final int MAX_ORDER_LIST_SIZE = 100;
 
     private final OrderRepository orderRepository;
     private final CartJPARepository cartJPARepository;
@@ -130,8 +135,18 @@ public class OrderServiceImpl implements OrderService {
      * 내 주문 목록 조회
      */
     @Override
-    public List<OrderResponse> getMyOrders(Long userId) {
-        List<Order> orders = orderRepository.findByUserIdWithItemsAndProduct(userId);
+    public List<OrderResponse> getMyOrders(Long userId, int page, int size) {
+        Pageable pageable = PageRequest.of(
+                Math.max(page, 0),
+                Math.min(Math.max(size, 1), MAX_ORDER_LIST_SIZE),
+                Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        List<Long> orderIds = orderRepository.findIdsByUserId(userId, pageable);
+        if (orderIds.isEmpty()) {
+            return List.of();
+        }
+
+        List<Order> orders = orderRepository.findByIdInWithItemsAndProduct(orderIds);
         return orders.stream()
                 .map(OrderResponse::from)
                 .toList();

--- a/src/test/java/com/homesweet/homesweetback/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/homesweet/homesweetback/domain/order/service/OrderServiceTest.java
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 
 import com.homesweet.homesweetback.common.exception.OrderNotFoundException;
 import com.homesweet.homesweetback.domain.auth.entity.User;
@@ -384,15 +386,18 @@ class OrderServiceTest {
                     createTestOrder(1L, user, OrderStatus.PENDING),
                     createTestOrder(2L, user, OrderStatus.PAID)
             );
+            PageRequest pageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "createdAt"));
 
-            given(orderRepository.findByUserIdWithItemsAndProduct(userId)).willReturn(orders);
+            given(orderRepository.findIdsByUserId(userId, pageable)).willReturn(List.of(1L, 2L));
+            given(orderRepository.findByIdInWithItemsAndProduct(List.of(1L, 2L))).willReturn(orders);
 
             // when
-            List<OrderResponse> responses = orderService.getMyOrders(userId);
+            List<OrderResponse> responses = orderService.getMyOrders(userId, 0, 20);
 
             // then
             assertThat(responses).hasSize(2);
-            verify(orderRepository, times(1)).findByUserIdWithItemsAndProduct(userId);
+            verify(orderRepository, times(1)).findIdsByUserId(userId, pageable);
+            verify(orderRepository, times(1)).findByIdInWithItemsAndProduct(List.of(1L, 2L));
         }
 
         @Test
@@ -400,14 +405,17 @@ class OrderServiceTest {
         void getMyOrders_Success_EmptyList() {
             // given
             Long userId = 1L;
+            PageRequest pageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "createdAt"));
 
-            given(orderRepository.findByUserIdWithItemsAndProduct(userId)).willReturn(List.of());
+            given(orderRepository.findIdsByUserId(userId, pageable)).willReturn(List.of());
 
             // when
-            List<OrderResponse> responses = orderService.getMyOrders(userId);
+            List<OrderResponse> responses = orderService.getMyOrders(userId, 0, 20);
 
             // then
             assertThat(responses).isEmpty();
+            verify(orderRepository, times(1)).findIdsByUserId(userId, pageable);
+            verify(orderRepository, never()).findByIdInWithItemsAndProduct(any());
         }
     }
 


### PR DESCRIPTION
refactor(order): 주문 목록 조회 성능 개선 및 페이징 도입
- 주문 내역 전체를 JOIN FETCH 하여 발생하던 메모리 낭비 및 지연 시간(latency) 증가 문제를 해결하기 위해 2단계 조회 방식 도입
- OrderRepository에 페이징을 적용하여 주문 ID 목록을 먼저 조회하는 findIdsByUserId 추가
- 추출한 ID 목록을 기반으로 연관 엔티티(Items, Product)를 한 번에 가져오는 findByIdInWithItemsAndProduct 추가
- OrderController의 조회 API에 page, size 파라미터 적용 (기본값 0, 20)
- K6 로드 테스트(order-payment-load-test.js) 스크립트에 페이징 쿼리 파라미터 반영
- 변경된 쿼리 로직에 맞춰 OrderServiceTest 테스트 코드 수정
- docker-compose.yml 백엔드 컨테이너 이미지 태그 업데이트 (3 -> 3.1)"

결과 order_list_latency (p95): 712.37ms -> 25.88ms (약 96% 감소, 27배 빨라짐)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pagination support to order lists, enabling users to browse through orders with customizable page and size parameters. Default page size is set to 20 items per page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->