### PR TITLE
test(order): 단일 SKU 경합 부하 테스트 시나리오 및 재고 지연 관측 로그 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   spring:
-    image: ohhalim/homesweet-commu:3.3
+    image: ohhalim/homesweet-commu:3.7
     container_name: homesweet-backend
     env_file:
       - .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   spring:
-    image: ohhalim/homesweet-commu:3
+    image: ohhalim/homesweet-commu:3.3
     container_name: homesweet-backend
     env_file:
       - .env

--- a/k6/README.md
+++ b/k6/README.md
@@ -23,6 +23,13 @@ k6 run k6/community-load-test.js
 # 서버 주소 변경
 k6 run -e BASE_URL=http://localhost:8080 k6/community-load-test.js
 
+# 딥 페이징 범위 확대 (0~49 페이지)
+k6 run -e COMMUNITY_LIST_PAGE_BOUND=50 k6/community-load-test.js
+
+# 쓰기 시나리오 userId 상한 조정
+# 주의: 게시글/댓글 작성은 실제 존재하는 userId만 사용해야 함
+k6 run -e COMMUNITY_USER_ID_MAX=10 k6/community-load-test.js
+
 # 간단 스모크 테스트 (VU 1명, 10초)
 k6 run --vus 1 --duration 10s k6/community-load-test.js
 ```
@@ -34,6 +41,46 @@ k6 run k6/order-payment-load-test.js
 
 # 서버 주소 변경
 k6 run -e BASE_URL=http://localhost:8080 k6/order-payment-load-test.js
+
+# 단일 SKU 집중 타격
+k6 run -e ORDER_HOT_SKU_ID=12345 k6/order-payment-load-test.js
+
+# 단일 SKU 검증 포함 실행
+k6 run -e ORDER_HOT_PRODUCT_ID=8801 -e ORDER_HOT_SKU_ID=12345 k6/order-payment-load-test.js
+
+# 주문 생성만 집중 테스트 (order_read 비활성화)
+k6 run \
+  -e ORDER_CHECKOUT_WARMUP_VUS=60 \
+  -e ORDER_CHECKOUT_PEAK_VUS=120 \
+  -e ORDER_READ_WARMUP_VUS=0 \
+  -e ORDER_READ_PEAK_VUS=0 \
+  -e ORDER_HOT_SKU_ID=12345 \
+  k6/order-payment-load-test.js
+
+# 공격형 락 경합 테스트
+# 상세 조회를 건너뛰고 sleep을 제거해 주문 생성/취소만 최대한 촘촘하게 반복
+k6 run \
+  -e BASE_URL=http://localhost:8080 \
+  -e ORDER_CHECKOUT_WARMUP_VUS=60 \
+  -e ORDER_CHECKOUT_PEAK_VUS=120 \
+  -e ORDER_READ_WARMUP_VUS=0 \
+  -e ORDER_READ_PEAK_VUS=0 \
+  -e ORDER_HOT_SKU_ID=12345 \
+  -e ORDER_AGGRESSIVE_MODE=true \
+  k6/order-payment-load-test.js
+
+# 더 극단적인 테스트
+# 주의: 취소까지 끄면 재고 소진이 락 경합보다 먼저 병목이 될 수 있음
+k6 run \
+  -e BASE_URL=http://localhost:8080 \
+  -e ORDER_CHECKOUT_WARMUP_VUS=60 \
+  -e ORDER_CHECKOUT_PEAK_VUS=120 \
+  -e ORDER_READ_WARMUP_VUS=0 \
+  -e ORDER_READ_PEAK_VUS=0 \
+  -e ORDER_HOT_SKU_ID=12345 \
+  -e ORDER_AGGRESSIVE_MODE=true \
+  -e ORDER_SKIP_CANCEL=true \
+  k6/order-payment-load-test.js
 
 # 간단 스모크 테스트
 k6 run --vus 1 --duration 10s k6/order-payment-load-test.js
@@ -47,11 +94,24 @@ k6 run --vus 1 --duration 10s k6/order-payment-load-test.js
 | read_heavy | 최대 50 VU | 80% | 게시글 목록/상세 조회, 조회수 증가, 댓글 조회 |
 | write_flow | 최대 10 VU | 20% | 게시글 작성, 댓글 달기, 좋아요 토글 |
 
+추가 옵션:
+- `COMMUNITY_LIST_PAGE_BOUND`: 목록 조회 페이지 난수 범위 상한. `50`이면 `0~49` 페이지에서 조회합니다.
+- `COMMUNITY_USER_ID_MAX`: `testUserId` 난수 상한. 쓰기 시나리오는 실제 존재하는 사용자 범위로만 늘리세요.
+
 ### order-payment-load-test.js
 | 시나리오 | 동시 유저 | 내용 |
 |---------|----------|------|
-| checkout_flow | 최대 15 VU | 주문 생성 -> 결제 승인 -> 상태 확인 풀 플로우 |
+| checkout_flow | 최대 15 VU | 주문 생성 -> 주문 상세 조회 -> 주문 취소 |
 | order_read | 최대 30 VU | 내 주문 목록 조회 |
+
+추가 옵션:
+- `ORDER_HOT_SKU_ID`: 모든 checkout 요청을 단일 SKU 하나에 집중시킵니다.
+- `ORDER_HOT_PRODUCT_ID`: `ORDER_HOT_SKU_ID` 검증용 상품 ID입니다. 같이 주면 setup 단계에서 재고를 확인합니다.
+- `ORDER_READ_WARMUP_VUS=0`, `ORDER_READ_PEAK_VUS=0`: `order_read` 시나리오를 완전히 비활성화합니다.
+- `ORDER_AGGRESSIVE_MODE=true`: 기본 sleep을 제거하고 `ORDER_SKIP_DETAIL=true`로 바꿔 락 경합 탐지에 집중합니다.
+- `ORDER_SKIP_DETAIL=true|false`: 주문 상세 조회 단계를 끕니다. 공격형 테스트에서는 기본값이 `true`입니다.
+- `ORDER_SKIP_CANCEL=true|false`: 주문 취소 단계를 끕니다. 끄면 재고가 빠르게 소진될 수 있습니다.
+- `ORDER_CREATE_TO_DETAIL_SLEEP_SEC`, `ORDER_DETAIL_TO_CANCEL_SLEEP_SEC`, `ORDER_CHECKOUT_LOOP_SLEEP_SEC`, `ORDER_READ_LOOP_SLEEP_SEC`, `ORDER_FAILURE_SLEEP_SEC`: 각 구간 sleep을 초 단위로 직접 제어합니다.
 
 ## 성능 기준 (thresholds)
 

--- a/k6/community-load-test.js
+++ b/k6/community-load-test.js
@@ -1,7 +1,6 @@
 import http from 'k6/http';
 import { check, sleep, group } from 'k6';
 import { Rate, Trend } from 'k6/metrics';
-import { SharedArray } from 'k6/data';
 
 // ============================================================
 // 설정
@@ -13,6 +12,8 @@ const COMMUNITY_READ_WARMUP_VUS = Number(__ENV.COMMUNITY_READ_WARMUP_VUS || 80);
 const COMMUNITY_READ_PEAK_VUS = Number(__ENV.COMMUNITY_READ_PEAK_VUS || 200);
 const COMMUNITY_WRITE_WARMUP_VUS = Number(__ENV.COMMUNITY_WRITE_WARMUP_VUS || 20);
 const COMMUNITY_WRITE_PEAK_VUS = Number(__ENV.COMMUNITY_WRITE_PEAK_VUS || 40);
+const COMMUNITY_LIST_PAGE_BOUND = Math.max(1, Number(__ENV.COMMUNITY_LIST_PAGE_BOUND || 3));
+const COMMUNITY_USER_ID_MAX = Math.max(1, Number(__ENV.COMMUNITY_USER_ID_MAX || 10));
 
 // 커스텀 메트릭
 const errorRate = new Rate('errors');
@@ -67,26 +68,7 @@ export const options = {
 const headers = { 'Content-Type': 'application/json' };
 
 function randomUserId() {
-  return Math.floor(Math.random() * 10) + 1;
-}
-
-/**
- * 목록 API에서 실제 존재하는 postId 목록을 가져온다.
- * 실패하면 빈 배열을 반환한다.
- */
-function fetchExistingPostIds() {
-  const res = http.get(`${API}/posts?page=0&size=50`);
-  if (res.status === 200) {
-    try {
-      const body = JSON.parse(res.body);
-      // Spring Page 응답: { content: [...], ... }
-      const content = body.content || [];
-      return content.map((p) => p.postId).filter((id) => id != null);
-    } catch (_) {
-      return [];
-    }
-  }
-  return [];
+  return Math.floor(Math.random() * COMMUNITY_USER_ID_MAX) + 1;
 }
 
 /**
@@ -106,7 +88,7 @@ export function readScenario() {
   let postIds = [];
 
   group('게시글 목록 조회', () => {
-    const page = Math.floor(Math.random() * 3);
+    const page = Math.floor(Math.random() * COMMUNITY_LIST_PAGE_BOUND);
     const res = http.get(`${API}/posts?page=${page}&size=10`);
     postListLatency.add(res.timings.duration);
     const ok = check(res, { '목록 조회 200': (r) => r.status === 200 });

--- a/k6/community-load-test.js
+++ b/k6/community-load-test.js
@@ -9,6 +9,10 @@ import { SharedArray } from 'k6/data';
 
 const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
 const API = `${BASE_URL}/api/v1/community`;
+const COMMUNITY_READ_WARMUP_VUS = Number(__ENV.COMMUNITY_READ_WARMUP_VUS || 80);
+const COMMUNITY_READ_PEAK_VUS = Number(__ENV.COMMUNITY_READ_PEAK_VUS || 200);
+const COMMUNITY_WRITE_WARMUP_VUS = Number(__ENV.COMMUNITY_WRITE_WARMUP_VUS || 20);
+const COMMUNITY_WRITE_PEAK_VUS = Number(__ENV.COMMUNITY_WRITE_PEAK_VUS || 40);
 
 // 커스텀 메트릭
 const errorRate = new Rate('errors');
@@ -28,9 +32,9 @@ export const options = {
       executor: 'ramping-vus',
       startVUs: 0,
       stages: [
-        { duration: '30s', target: 20 },  // 웜업
-        { duration: '1m', target: 50 },   // 부하 증가
-        { duration: '2m', target: 50 },   // 유지
+        { duration: '30s', target: COMMUNITY_READ_WARMUP_VUS },  // 웜업
+        { duration: '1m', target: COMMUNITY_READ_PEAK_VUS },     // 부하 증가
+        { duration: '2m', target: COMMUNITY_READ_PEAK_VUS },     // 유지
         { duration: '30s', target: 0 },   // 정리
       ],
       exec: 'readScenario',
@@ -40,9 +44,9 @@ export const options = {
       executor: 'ramping-vus',
       startVUs: 0,
       stages: [
-        { duration: '30s', target: 5 },
-        { duration: '1m', target: 10 },
-        { duration: '2m', target: 10 },
+        { duration: '30s', target: COMMUNITY_WRITE_WARMUP_VUS },
+        { duration: '1m', target: COMMUNITY_WRITE_PEAK_VUS },
+        { duration: '2m', target: COMMUNITY_WRITE_PEAK_VUS },
         { duration: '30s', target: 0 },
       ],
       exec: 'writeScenario',

--- a/k6/order-payment-load-test.js
+++ b/k6/order-payment-load-test.js
@@ -18,6 +18,31 @@ const ORDER_CHECKOUT_WARMUP_VUS = Number(__ENV.ORDER_CHECKOUT_WARMUP_VUS || 20);
 const ORDER_CHECKOUT_PEAK_VUS = Number(__ENV.ORDER_CHECKOUT_PEAK_VUS || 60);
 const ORDER_READ_WARMUP_VUS = Number(__ENV.ORDER_READ_WARMUP_VUS || 40);
 const ORDER_READ_PEAK_VUS = Number(__ENV.ORDER_READ_PEAK_VUS || 120);
+const ORDER_HOT_SKU_ID = Number(__ENV.ORDER_HOT_SKU_ID || 0);
+const ORDER_HOT_PRODUCT_ID = Number(__ENV.ORDER_HOT_PRODUCT_ID || 0);
+const ORDER_AGGRESSIVE_MODE = parseBooleanEnv(__ENV.ORDER_AGGRESSIVE_MODE, false);
+const ORDER_SKIP_DETAIL = parseBooleanEnv(__ENV.ORDER_SKIP_DETAIL, ORDER_AGGRESSIVE_MODE);
+const ORDER_SKIP_CANCEL = parseBooleanEnv(__ENV.ORDER_SKIP_CANCEL, false);
+const ORDER_CREATE_TO_DETAIL_SLEEP_SEC = resolveSecondsEnv(
+  'ORDER_CREATE_TO_DETAIL_SLEEP_SEC',
+  ORDER_AGGRESSIVE_MODE ? 0 : 0.5
+);
+const ORDER_DETAIL_TO_CANCEL_SLEEP_SEC = resolveSecondsEnv(
+  'ORDER_DETAIL_TO_CANCEL_SLEEP_SEC',
+  ORDER_AGGRESSIVE_MODE ? 0 : 0.5
+);
+const ORDER_CHECKOUT_LOOP_SLEEP_SEC = resolveSecondsEnv(
+  'ORDER_CHECKOUT_LOOP_SLEEP_SEC',
+  ORDER_AGGRESSIVE_MODE ? 0 : 2
+);
+const ORDER_FAILURE_SLEEP_SEC = resolveSecondsEnv(
+  'ORDER_FAILURE_SLEEP_SEC',
+  ORDER_AGGRESSIVE_MODE ? 0 : 2
+);
+const ORDER_READ_LOOP_SLEEP_SEC = resolveSecondsEnv(
+  'ORDER_READ_LOOP_SLEEP_SEC',
+  ORDER_AGGRESSIVE_MODE ? 0 : 1
+);
 
 // 커스텀 메트릭
 const errorRate = new Rate('errors');
@@ -30,33 +55,59 @@ const orderCancelLatency = new Trend('order_cancel_latency', true);
 // 시나리오 설정
 // ============================================================
 
+function parseBooleanEnv(value, defaultValue) {
+  if (value === undefined) {
+    return defaultValue;
+  }
+  return ['1', 'true', 'yes', 'on'].includes(String(value).toLowerCase());
+}
+
+function resolveSecondsEnv(name, defaultValue) {
+  const raw = __ENV[name];
+  if (raw === undefined) {
+    return defaultValue;
+  }
+  return Math.max(0, Number(raw));
+}
+
+function createRampingVusScenario(warmupVus, peakVus, exec) {
+  return {
+    executor: 'ramping-vus',
+    startVUs: 0,
+    stages: [
+      { duration: '30s', target: warmupVus },
+      { duration: '1m', target: peakVus },
+      { duration: '2m', target: peakVus },
+      { duration: '30s', target: 0 },
+    ],
+    exec,
+  };
+}
+
+const scenarios = {};
+
+if (ORDER_CHECKOUT_WARMUP_VUS > 0 || ORDER_CHECKOUT_PEAK_VUS > 0) {
+  scenarios.checkout_flow = createRampingVusScenario(
+    ORDER_CHECKOUT_WARMUP_VUS,
+    ORDER_CHECKOUT_PEAK_VUS,
+    'checkoutFlow'
+  );
+}
+
+if (ORDER_READ_WARMUP_VUS > 0 || ORDER_READ_PEAK_VUS > 0) {
+  scenarios.order_read = createRampingVusScenario(
+    ORDER_READ_WARMUP_VUS,
+    ORDER_READ_PEAK_VUS,
+    'orderReadFlow'
+  );
+}
+
+if (Object.keys(scenarios).length === 0) {
+  throw new Error('최소 하나의 주문 시나리오는 활성화되어야 합니다.');
+}
+
 export const options = {
-  scenarios: {
-    // 주문 생성 → 조회 플로우
-    checkout_flow: {
-      executor: 'ramping-vus',
-      startVUs: 0,
-      stages: [
-        { duration: '30s', target: ORDER_CHECKOUT_WARMUP_VUS },
-        { duration: '1m', target: ORDER_CHECKOUT_PEAK_VUS },
-        { duration: '2m', target: ORDER_CHECKOUT_PEAK_VUS },
-        { duration: '30s', target: 0 },
-      ],
-      exec: 'checkoutFlow',
-    },
-    // 주문 목록 조회 (읽기)
-    order_read: {
-      executor: 'ramping-vus',
-      startVUs: 0,
-      stages: [
-        { duration: '30s', target: ORDER_READ_WARMUP_VUS },
-        { duration: '1m', target: ORDER_READ_PEAK_VUS },
-        { duration: '2m', target: ORDER_READ_PEAK_VUS },
-        { duration: '30s', target: 0 },
-      ],
-      exec: 'orderReadFlow',
-    },
-  },
+  scenarios,
   thresholds: {
     http_req_duration: ['p(95)<500', 'p(99)<1000'],
     errors: ['rate<0.05'],
@@ -71,6 +122,37 @@ export const options = {
 // ============================================================
 
 export function setup() {
+  if (ORDER_HOT_SKU_ID > 0) {
+    if (ORDER_HOT_PRODUCT_ID > 0) {
+      const res = http.get(`${PRODUCT_API}/${ORDER_HOT_PRODUCT_ID}/stocks`);
+      if (res.status === 200) {
+        try {
+          const stocks = JSON.parse(res.body);
+          const hotSku = stocks.find((stock) => stock.skuId === ORDER_HOT_SKU_ID);
+          if (!hotSku) {
+            console.error(
+              `ORDER_HOT_PRODUCT_ID=${ORDER_HOT_PRODUCT_ID} 에서 ORDER_HOT_SKU_ID=${ORDER_HOT_SKU_ID} 를 찾지 못했습니다.`
+            );
+            return { skuIds: [] };
+          }
+          if (hotSku.stockQuantity <= 0) {
+            console.error(`ORDER_HOT_SKU_ID=${ORDER_HOT_SKU_ID} 의 재고가 부족합니다.`);
+            return { skuIds: [] };
+          }
+        } catch (_) {
+          console.error('단일 SKU 검증 응답 파싱에 실패했습니다.');
+          return { skuIds: [] };
+        }
+      } else {
+        console.error(`단일 SKU 검증 요청 실패: productId=${ORDER_HOT_PRODUCT_ID}, status=${res.status}`);
+        return { skuIds: [] };
+      }
+    }
+
+    console.log(`단일 SKU 집중 타격 모드: skuId=${ORDER_HOT_SKU_ID}`);
+    return { skuIds: [ORDER_HOT_SKU_ID] };
+  }
+
   const skuIds = [];
   // 테스트 데이터 상품 ID 목록 (DB에 존재하는 값)
   const productIds = [8801, 8802, 8803, 8804, 8805];
@@ -108,6 +190,20 @@ function randomFrom(arr) {
   return arr[Math.floor(Math.random() * arr.length)];
 }
 
+function requestParams(name, customHeaders) {
+  const params = { tags: { name } };
+  if (customHeaders) {
+    params.headers = customHeaders;
+  }
+  return params;
+}
+
+function sleepIfNeeded(seconds) {
+  if (seconds > 0) {
+    sleep(seconds);
+  }
+}
+
 // ============================================================
 // 주문 생성 → 상세 조회 → 취소 플로우
 // (결제 승인은 토스 실환경 없이 불가 → 단위/통합 테스트로 검증)
@@ -117,7 +213,7 @@ export function checkoutFlow(data) {
   const skuIds = data.skuIds;
   if (!skuIds || skuIds.length === 0) {
     console.error('SKU ID 목록이 없습니다. setup()을 확인하세요.');
-    sleep(2);
+    sleepIfNeeded(ORDER_FAILURE_SLEEP_SEC);
     return;
   }
 
@@ -135,7 +231,11 @@ export function checkoutFlow(data) {
       shippingRequest: '문 앞에 놓아주세요',
     });
 
-    const res = http.post(`${ORDER_API}?testUserId=${userId}`, payload, { headers });
+    const res = http.post(
+      http.url`${ORDER_API}?testUserId=${userId}`,
+      payload,
+      requestParams('order_create', headers)
+    );
     orderCreateLatency.add(res.timings.duration);
 
     const ok = check(res, { '주문 생성 201': (r) => r.status === 201 });
@@ -147,39 +247,48 @@ export function checkoutFlow(data) {
   });
 
   if (!orderId) {
-    sleep(2);
+    sleepIfNeeded(ORDER_FAILURE_SLEEP_SEC);
     return;
   }
 
-  sleep(0.5);
+  sleepIfNeeded(ORDER_CREATE_TO_DETAIL_SLEEP_SEC);
 
-  // 2. 주문 상세 조회
-  group('주문 상세 조회', () => {
-    const res = http.get(`${ORDER_API}/${orderId}?testUserId=${userId}`);
-    orderDetailLatency.add(res.timings.duration);
+  if (!ORDER_SKIP_DETAIL) {
+    group('주문 상세 조회', () => {
+      const res = http.get(
+        http.url`${ORDER_API}/${orderId}?testUserId=${userId}`,
+        requestParams('order_detail')
+      );
+      orderDetailLatency.add(res.timings.duration);
 
-    const ok = check(res, {
-      '주문 상세 200': (r) => r.status === 200,
-      '상태 PENDING': (r) => {
-        try { return JSON.parse(r.body).status === 'PENDING'; }
-        catch { return false; }
-      },
+      const ok = check(res, {
+        '주문 상세 200': (r) => r.status === 200,
+        '상태 PENDING': (r) => {
+          try { return JSON.parse(r.body).status === 'PENDING'; }
+          catch { return false; }
+        },
+      });
+      errorRate.add(!ok);
     });
-    errorRate.add(!ok);
-  });
+  }
 
-  sleep(0.5);
+  sleepIfNeeded(ORDER_DETAIL_TO_CANCEL_SLEEP_SEC);
 
-  // 3. 주문 취소 (재고 복원 포함)
-  group('주문 취소', () => {
-    const res = http.del(`${ORDER_API}/${orderId}?testUserId=${userId}`);
-    orderCancelLatency.add(res.timings.duration);
+  if (!ORDER_SKIP_CANCEL) {
+    group('주문 취소', () => {
+      const res = http.del(
+        http.url`${ORDER_API}/${orderId}?testUserId=${userId}`,
+        null,
+        requestParams('order_cancel')
+      );
+      orderCancelLatency.add(res.timings.duration);
 
-    const ok = check(res, { '주문 취소 204': (r) => r.status === 204 });
-    errorRate.add(!ok);
-  });
+      const ok = check(res, { '주문 취소 204': (r) => r.status === 204 });
+      errorRate.add(!ok);
+    });
+  }
 
-  sleep(2);
+  sleepIfNeeded(ORDER_CHECKOUT_LOOP_SLEEP_SEC);
 }
 
 // ============================================================
@@ -190,12 +299,15 @@ export function orderReadFlow(data) {
   const userId = randomUserId();
 
   group('내 주문 목록', () => {
-    const res = http.get(`${ORDER_API}?testUserId=${userId}&page=0&size=20`);
+    const res = http.get(
+      http.url`${ORDER_API}?testUserId=${userId}&page=0&size=20`,
+      requestParams('order_list')
+    );
     orderListLatency.add(res.timings.duration);
 
     const ok = check(res, { '목록 조회 200': (r) => r.status === 200 });
     errorRate.add(!ok);
   });
 
-  sleep(1);
+  sleepIfNeeded(ORDER_READ_LOOP_SLEEP_SEC);
 }

--- a/k6/order-payment-load-test.js
+++ b/k6/order-payment-load-test.js
@@ -14,6 +14,10 @@ import { Rate, Trend } from 'k6/metrics';
 const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
 const ORDER_API = `${BASE_URL}/api/v1/orders`;
 const PRODUCT_API = `${BASE_URL}/api/v1/products`;
+const ORDER_CHECKOUT_WARMUP_VUS = Number(__ENV.ORDER_CHECKOUT_WARMUP_VUS || 20);
+const ORDER_CHECKOUT_PEAK_VUS = Number(__ENV.ORDER_CHECKOUT_PEAK_VUS || 60);
+const ORDER_READ_WARMUP_VUS = Number(__ENV.ORDER_READ_WARMUP_VUS || 40);
+const ORDER_READ_PEAK_VUS = Number(__ENV.ORDER_READ_PEAK_VUS || 120);
 
 // 커스텀 메트릭
 const errorRate = new Rate('errors');
@@ -33,9 +37,9 @@ export const options = {
       executor: 'ramping-vus',
       startVUs: 0,
       stages: [
-        { duration: '30s', target: 5 },
-        { duration: '1m', target: 15 },
-        { duration: '2m', target: 15 },
+        { duration: '30s', target: ORDER_CHECKOUT_WARMUP_VUS },
+        { duration: '1m', target: ORDER_CHECKOUT_PEAK_VUS },
+        { duration: '2m', target: ORDER_CHECKOUT_PEAK_VUS },
         { duration: '30s', target: 0 },
       ],
       exec: 'checkoutFlow',
@@ -45,9 +49,9 @@ export const options = {
       executor: 'ramping-vus',
       startVUs: 0,
       stages: [
-        { duration: '30s', target: 10 },
-        { duration: '1m', target: 30 },
-        { duration: '2m', target: 30 },
+        { duration: '30s', target: ORDER_READ_WARMUP_VUS },
+        { duration: '1m', target: ORDER_READ_PEAK_VUS },
+        { duration: '2m', target: ORDER_READ_PEAK_VUS },
         { duration: '30s', target: 0 },
       ],
       exec: 'orderReadFlow',

--- a/src/main/java/com/homesweet/homesweetback/domain/order/service/OrderServiceImpl.java
+++ b/src/main/java/com/homesweet/homesweetback/domain/order/service/OrderServiceImpl.java
@@ -17,6 +17,7 @@ import com.homesweet.homesweetback.domain.product.product.command.repository.jpa
 import com.homesweet.homesweetback.domain.product.product.command.repository.jpa.entity.SkuEntity;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -30,6 +31,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 /**
@@ -48,11 +50,15 @@ public class OrderServiceImpl implements OrderService {
     private static final int SHIPPING_REQUEST_MAX_LENGTH = 500;
     private static final int DEFAULT_ORDER_LIST_SIZE = 20;
     private static final int MAX_ORDER_LIST_SIZE = 100;
+    private static final String ORDER_PERF_LOG_PREFIX = "[ORDER-PERF]";
 
     private final OrderRepository orderRepository;
     private final CartJPARepository cartJPARepository;
     private final SkuJPARepository skuJPARepository;
     private final UserRepository userRepository;
+
+    @Value("${order.observability.slow-threshold-ms:500}")
+    private long slowThresholdMs;
 
     /**
      * 주문 생성
@@ -61,6 +67,7 @@ public class OrderServiceImpl implements OrderService {
     @Override
     @Transactional
     public OrderResponse createFromCart(Long userId, CreateOrderRequest request) {
+        long transactionStart = System.nanoTime();
         if (request == null) {
             throw new IllegalArgumentException("주문 요청이 비어 있습니다.");
         }
@@ -80,7 +87,9 @@ public class OrderServiceImpl implements OrderService {
         Map<Long, SkuEntity> skuMap = loadSkuMap(skuQuantitiesById.keySet().stream().toList());
         long totalAmount = calculateTotalAmount(skuQuantitiesById, skuMap);
 
+        long reserveStockStart = System.nanoTime();
         reserveStock(skuQuantitiesById);
+        long reserveStockMs = elapsedMillis(reserveStockStart);
 
         Order order = Order.builder()
                 .user(user)
@@ -109,9 +118,13 @@ public class OrderServiceImpl implements OrderService {
             order.addOrderItem(orderItem);
         }
 
+        long persistStart = System.nanoTime();
         Order savedOrder = orderRepository.save(order);
+        long persistMs = elapsedMillis(persistStart);
+        long businessMs = elapsedMillis(transactionStart);
         log.info("주문 생성 완료: orderId={}, orderNumber={}, totalAmount={}",
                 savedOrder.getId(), savedOrder.getOrderNumber(), savedOrder.getTotalAmount());
+        logSlowCreateTransaction(userId, savedOrder.getOrderNumber(), skuQuantitiesById, reserveStockMs, persistMs, businessMs);
 
         return OrderResponse.from(savedOrder);
     }
@@ -159,6 +172,7 @@ public class OrderServiceImpl implements OrderService {
     @Override
     @Transactional
     public void cancelOrder(Long orderId, Long userId) {
+        long transactionStart = System.nanoTime();
         Order order = orderRepository.findByIdWithItems(orderId)
                 .orElseThrow(() -> new OrderNotFoundException("주문을 찾을 수 없습니다. orderId=" + orderId));
 
@@ -171,10 +185,14 @@ public class OrderServiceImpl implements OrderService {
         }
 
         // 재고 복원
+        long restoreStockStart = System.nanoTime();
         restoreStock(order);
+        long restoreStockMs = elapsedMillis(restoreStockStart);
 
         order.cancel();
+        long businessMs = elapsedMillis(transactionStart);
         log.info("주문 취소 완료: orderId={}", orderId);
+        logSlowCancelTransaction(userId, orderId, order, restoreStockMs, businessMs);
     }
 
     /**
@@ -182,7 +200,10 @@ public class OrderServiceImpl implements OrderService {
      */
     private void restoreStock(Order order) {
         for (OrderItem item : order.getOrderItems()) {
+            long stockUpdateStart = System.nanoTime();
             skuJPARepository.increaseStock(item.getSku().getId(), item.getQuantity());
+            long stockUpdateMs = elapsedMillis(stockUpdateStart);
+            logSlowStockMutation("increase", item.getSku().getId(), item.getQuantity(), stockUpdateMs, 1);
             log.info("재고 복원: skuId={}, quantity={}", item.getSku().getId(), item.getQuantity());
         }
     }
@@ -297,7 +318,10 @@ public class OrderServiceImpl implements OrderService {
             for (Map.Entry<Long, Integer> entry : skuQuantitiesById.entrySet()) {
                 Long skuId = entry.getKey();
                 long quantity = entry.getValue().longValue();
+                long stockUpdateStart = System.nanoTime();
                 int updatedRows = skuJPARepository.decreaseStock(skuId, quantity);
+                long stockUpdateMs = elapsedMillis(stockUpdateStart);
+                logSlowStockMutation("decrease", skuId, quantity, stockUpdateMs, updatedRows);
                 if (updatedRows == 0) {
                     throw new StockInsufficientException(
                             "재고가 부족합니다. (SKU: " + skuId + ", 요청 수량: " + quantity + ")");
@@ -354,6 +378,54 @@ public class OrderServiceImpl implements OrderService {
         if (value.length() > maxLength) {
             throw new IllegalArgumentException(message);
         }
+    }
+
+    private long elapsedMillis(long startNanos) {
+        return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+    }
+
+    private void logSlowStockMutation(String action, Long skuId, Long quantity, long durationMs, int updatedRows) {
+        if (durationMs < slowThresholdMs) {
+            return;
+        }
+        log.warn(
+                "{} stock-update slow action={}, skuId={}, quantity={}, durationMs={}, updatedRows={}",
+                ORDER_PERF_LOG_PREFIX, action, skuId, quantity, durationMs, updatedRows
+        );
+    }
+
+    private void logSlowCreateTransaction(
+            Long userId,
+            String orderNumber,
+            Map<Long, Integer> skuQuantitiesById,
+            long reserveStockMs,
+            long persistMs,
+            long businessMs
+    ) {
+        if (reserveStockMs < slowThresholdMs && businessMs < slowThresholdMs) {
+            return;
+        }
+        log.warn(
+                "{} create slow userId={}, orderNumber={}, skuQuantities={}, reserveStockMs={}, persistMs={}, businessMs={}",
+                ORDER_PERF_LOG_PREFIX, userId, orderNumber, skuQuantitiesById, reserveStockMs, persistMs, businessMs
+        );
+    }
+
+    private void logSlowCancelTransaction(Long userId, Long orderId, Order order, long restoreStockMs, long businessMs) {
+        if (restoreStockMs < slowThresholdMs && businessMs < slowThresholdMs) {
+            return;
+        }
+        Map<Long, Long> restoreQuantities = order.getOrderItems().stream()
+                .collect(Collectors.toMap(
+                        item -> item.getSku().getId(),
+                        OrderItem::getQuantity,
+                        Long::sum,
+                        LinkedHashMap::new
+                ));
+        log.warn(
+                "{} cancel slow userId={}, orderId={}, skuQuantities={}, restoreStockMs={}, businessMs={}",
+                ORDER_PERF_LOG_PREFIX, userId, orderId, restoreQuantities, restoreStockMs, businessMs
+        );
     }
 
     /**


### PR DESCRIPTION
## 변경 배경

단일 SKU에 주문이 몰리는 상황에서 실제 병목이 어디서 발생하는지 재현하고,
리팩토링 전후 성능 차이를 확인할 수 있도록 부하 테스트 시나리오와 관측 로그를 추가했다.

특히 hot SKU + checkout-only + aggressive 시나리오에서
주문 생성/취소 latency가 함께 증가하는 현상을 재현할 수 있도록 구성했고,
앱 로그에서도 재고 차감/복원 구간 지연을 직접 확인할 수 있게 했다.

## 변경 내용

### k6 부하 테스트 고도화
- `community-load-test.js`
  - `COMMUNITY_LIST_PAGE_BOUND` 추가
  - `COMMUNITY_USER_ID_MAX` 추가
- `order-payment-load-test.js`
  - `ORDER_HOT_SKU_ID`, `ORDER_HOT_PRODUCT_ID` 추가
  - `ORDER_READ_* = 0`일 때 `order_read` 시나리오 비활성화
  - `ORDER_AGGRESSIVE_MODE` 추가
  - `ORDER_SKIP_DETAIL`, `ORDER_SKIP_CANCEL` 추가
  - 각 구간 sleep을 env로 제어할 수 있도록 변경
  - 동적 URL 요청에 `name` 태그를 부여해 k6 metric cardinality를 줄이도록 개선
- `k6/README.md`
  - deep pagination, hot SKU, checkout-only, aggressive mode 실행 예시 추가

### 주문 성능 관측 로그 추가
- `OrderServiceImpl`
  - 재고 차감(`decreaseStock`) 지연 로그 추가
  - 재고 복원(`increaseStock`) 지연 로그 추가
  - 주문 생성/취소 전체 처리 시간 로그 추가
  - `order.observability.slow-threshold-ms` 설정값으로 slow log 임계값 제어 가능
  - slow log prefix: `[ORDER-PERF]`

## 기대 효과

- 단일 SKU 집중 주문 시나리오를 반복 가능하게 재현할 수 있음
- 주문 생성/취소 지연이 실제로 재고 update 구간에서 발생하는지 로그로 확인 가능
- 리팩토링 전후 성능 비교 근거를 남길 수 있음

## 검증

- `k6 inspect k6/community-load-test.js`
- `k6 inspect k6/order-payment-load-test.js`
- `k6 inspect -e ORDER_CHECKOUT_WARMUP_VUS=60 -e ORDER_CHECKOUT_PEAK_VUS=120 -e ORDER_READ_WARMUP_VUS=0 -e ORDER_READ_PEAK_VUS=0 -e ORDER_HOT_SKU_ID=99001 -e ORDER_AGGRESSIVE_MODE=true k6/order-payment-load-test.js`
- `./gradlew compileJava`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend service to version 3.7
  * Enhanced performance observability and monitoring for critical operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->