### PR TITLE
perf(order): Redis→DB 비동기 재고 동기화 및 결제 취소 재고 복원 누락 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   spring:
-    image: ohhalim/homesweet-commu:6
+    image: ohhalim/homesweet-commu:8
     container_name: homesweet-backend
     env_file:
       - .env

--- a/src/main/java/com/homesweet/homesweetback/common/config/AsyncConfig.java
+++ b/src/main/java/com/homesweet/homesweetback/common/config/AsyncConfig.java
@@ -96,4 +96,27 @@ public class AsyncConfig {
         executor.initialize();
         return executor;
     }
+
+    /**
+     * 재고 DB 동기화 전용 스레드 풀
+     *
+     * AFTER_COMMIT 리스너를 비동기로 실행해 요청 스레드의 HikariCP 커넥션을
+     * 먼저 반환한 뒤 별도 스레드에서 DB sync를 처리한다.
+     * REQUIRES_NEW를 요청 스레드에서 쓰면 커넥션을 2개 잡아 풀 고갈이 발생한다.
+     */
+    @Bean(name = "stockSyncExecutor")
+    public Executor stockSyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(200);
+        executor.setThreadNamePrefix("stock-sync-");
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(60);
+        executor.setRejectedExecutionHandler((r, executor1) -> {
+            log.error("[STOCK-SYNC] stockSyncExecutor 큐 포화 — DB sync 유실. reconciliation 필요.");
+        });
+        executor.initialize();
+        return executor;
+    }
 }

--- a/src/main/java/com/homesweet/homesweetback/domain/order/service/OrderServiceImpl.java
+++ b/src/main/java/com/homesweet/homesweetback/domain/order/service/OrderServiceImpl.java
@@ -18,6 +18,7 @@ import com.homesweet.homesweetback.domain.product.product.command.repository.jpa
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -57,6 +58,7 @@ public class OrderServiceImpl implements OrderService {
     private final SkuJPARepository skuJPARepository;
     private final UserRepository userRepository;
     private final StockCacheService stockCacheService;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Value("${order.observability.slow-threshold-ms:500}")
     private long slowThresholdMs;
@@ -207,6 +209,7 @@ public class OrderServiceImpl implements OrderService {
 
             // Redis 원자적 복원만 — DB row lock 완전 제거
             stockCacheService.restore(skuId, quantity);
+            eventPublisher.publishEvent(StockDeltaEvent.increase(skuId, quantity));
 
             long stockUpdateMs = elapsedMillis(stockUpdateStart);
             logSlowStockMutation("increase", skuId, quantity, stockUpdateMs, 1);
@@ -329,6 +332,7 @@ public class OrderServiceImpl implements OrderService {
                 // Redis 원자적 차감만 — DB row lock 완전 제거
                 stockCacheService.decrease(skuId, quantity);
                 decreasedEntries.add(entry);
+                eventPublisher.publishEvent(StockDeltaEvent.decrease(skuId, quantity));
 
                 long stockUpdateMs = elapsedMillis(stockUpdateStart);
                 logSlowStockMutation("decrease", skuId, quantity, stockUpdateMs, 1);

--- a/src/main/java/com/homesweet/homesweetback/domain/order/service/PaymentServiceImpl.java
+++ b/src/main/java/com/homesweet/homesweetback/domain/order/service/PaymentServiceImpl.java
@@ -13,6 +13,7 @@ import com.homesweet.homesweetback.domain.order.repository.PaymentRepository;
 import com.homesweet.homesweetback.domain.product.cart.repository.jpa.CartJPARepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,6 +41,8 @@ public class PaymentServiceImpl implements PaymentService {
     private final PaymentRepository paymentRepository;
     private final OrderRepository orderRepository;
     private final CartJPARepository cartJPARepository;
+    private final StockCacheService stockCacheService;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 결제 승인 처리
@@ -133,9 +136,15 @@ public class PaymentServiceImpl implements PaymentService {
 
         if (fullCancel) {
             payment.cancel();
-            // 주문 취소 + 재고 복원
             Order order = payment.getOrder();
             order.cancel();
+            // 재고 Redis 복원 + DB sync 이벤트 발행
+            order.getOrderItems().forEach(item -> {
+                Long skuId = item.getSku().getId();
+                long qty = item.getQuantity();
+                stockCacheService.restore(skuId, qty);
+                eventPublisher.publishEvent(StockDeltaEvent.increase(skuId, qty));
+            });
         } else {
             payment.partialCancel();
         }

--- a/src/main/java/com/homesweet/homesweetback/domain/order/service/StockDeltaEvent.java
+++ b/src/main/java/com/homesweet/homesweetback/domain/order/service/StockDeltaEvent.java
@@ -1,0 +1,25 @@
+package com.homesweet.homesweetback.domain.order.service;
+
+/**
+ * 재고 변경 이벤트
+ *
+ * 주문 생성/취소 트랜잭션 내에서 발행되며,
+ * AFTER_COMMIT → DB 재고 동기화
+ * AFTER_ROLLBACK → Redis 재고 보상 (DECREASE 실패 시)
+ * 에 사용된다.
+ */
+public record StockDeltaEvent(Long skuId, long quantity, Type type) {
+
+    public enum Type {
+        DECREASE,
+        INCREASE
+    }
+
+    public static StockDeltaEvent decrease(Long skuId, long quantity) {
+        return new StockDeltaEvent(skuId, quantity, Type.DECREASE);
+    }
+
+    public static StockDeltaEvent increase(Long skuId, long quantity) {
+        return new StockDeltaEvent(skuId, quantity, Type.INCREASE);
+    }
+}

--- a/src/main/java/com/homesweet/homesweetback/domain/order/service/StockSyncEventListener.java
+++ b/src/main/java/com/homesweet/homesweetback/domain/order/service/StockSyncEventListener.java
@@ -1,0 +1,71 @@
+package com.homesweet.homesweetback.domain.order.service;
+
+import com.homesweet.homesweetback.domain.product.product.command.repository.jpa.SkuJPARepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * 재고 변경 이벤트 리스너
+ *
+ * AFTER_COMMIT: DB 재고 동기화 (REQUIRES_NEW — 메인 TX와 별도 짧은 트랜잭션)
+ * AFTER_ROLLBACK: Redis 재고 보상 — 주문 생성 TX 롤백 시 Redis에 차감된 재고를 복원
+ *
+ * DB sync 실패 시 예외를 삼켜 HTTP 500을 방지한다.
+ * 이미 커밋된 주문에 500을 돌려주는 것보다 로그 + reconciliation이 낫다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StockSyncEventListener {
+
+    private final SkuJPARepository skuJPARepository;
+    private final StockCacheService stockCacheService;
+
+    @Async("stockSyncExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void onCommit(StockDeltaEvent event) {
+        try {
+            if (event.type() == StockDeltaEvent.Type.DECREASE) {
+                skuJPARepository.decreaseStockDirect(event.skuId(), event.quantity());
+            } else {
+                skuJPARepository.increaseStock(event.skuId(), event.quantity());
+            }
+            log.info("[STOCK-SYNC] DB synced skuId={}, qty={}, type={}",
+                    event.skuId(), event.quantity(), event.type());
+        } catch (Exception e) {
+            // 주문은 이미 커밋 — 500 던지지 않고 로그만 남긴다.
+            // reconciliation 스케줄러가 나중에 Redis ↔ DB 불일치를 잡아준다.
+            log.error("[STOCK-SYNC] DB sync failed — needs reconciliation. skuId={}, qty={}, type={}",
+                    event.skuId(), event.quantity(), event.type(), e);
+        }
+    }
+
+    /**
+     * 주문 생성 TX가 롤백된 경우 Redis에서 차감된 재고를 복원한다.
+     * INCREASE(취소) 롤백은 reconciliation에 위임한다 (취소 TX 자체가 롤백되는 케이스는 매우 드물고
+     * 반대 방향 decrease를 여기서 쏘면 ensureInitialized 등 side-effect가 생길 수 있다).
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_ROLLBACK)
+    public void onRollback(StockDeltaEvent event) {
+        if (event.type() != StockDeltaEvent.Type.DECREASE) {
+            log.warn("[STOCK-SYNC] INCREASE event rolled back — reconciliation needed. skuId={}, qty={}",
+                    event.skuId(), event.quantity());
+            return;
+        }
+        try {
+            stockCacheService.restore(event.skuId(), event.quantity());
+            log.warn("[STOCK-SYNC] TX rolled back, Redis restored. skuId={}, qty={}",
+                    event.skuId(), event.quantity());
+        } catch (Exception e) {
+            log.error("[STOCK-SYNC] Redis restore failed after rollback. skuId={}, qty={}",
+                    event.skuId(), event.quantity(), e);
+        }
+    }
+}

--- a/src/test/java/com/homesweet/homesweetback/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/homesweet/homesweetback/domain/order/service/OrderServiceTest.java
@@ -41,6 +41,7 @@ import com.homesweet.homesweetback.domain.product.product.command.repository.jpa
 import com.homesweet.homesweetback.domain.product.product.command.repository.jpa.entity.ProductEntity;
 import com.homesweet.homesweetback.domain.product.product.command.repository.jpa.entity.SkuEntity;
 import com.homesweet.homesweetback.domain.order.service.StockCacheService;
+import org.springframework.context.ApplicationEventPublisher;
 
 /**
  * OrderService 단위 테스트
@@ -74,6 +75,9 @@ class OrderServiceTest {
 
     @Mock
     private StockCacheService stockCacheService;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
 
     @InjectMocks
     private OrderServiceImpl orderService;

--- a/src/test/java/com/homesweet/homesweetback/domain/order/service/PaymentServiceTest.java
+++ b/src/test/java/com/homesweet/homesweetback/domain/order/service/PaymentServiceTest.java
@@ -34,7 +34,9 @@ import com.homesweet.homesweetback.domain.order.entity.Payment;
 import com.homesweet.homesweetback.domain.order.entity.PaymentStatus;
 import com.homesweet.homesweetback.domain.order.repository.OrderRepository;
 import com.homesweet.homesweetback.domain.order.repository.PaymentRepository;
+import com.homesweet.homesweetback.domain.order.service.StockCacheService;
 import com.homesweet.homesweetback.domain.product.cart.repository.jpa.CartJPARepository;
+import org.springframework.context.ApplicationEventPublisher;
 
 /**
  * PaymentService 단위 테스트
@@ -55,6 +57,12 @@ class PaymentServiceTest {
 
     @Mock
     private CartJPARepository cartJPARepository;
+
+    @Mock
+    private StockCacheService stockCacheService;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
 
     @InjectMocks
     private PaymentServiceImpl paymentService;


### PR DESCRIPTION
## 문제 정의

이전 작업(https://github.com/ohhalim/HomeSweetHome-backend/commit/76b3221439c414d18d87d3b225755f856003dfd4)에서 재고 차감을 Redis DECRBY로 교체해 DB row lock을 제거했으나
두 가지 문제가 남아 있었음.

1. Redis ↔ DB 재고 불일치
   - Redis만 업데이트되고 DB stock_quantity는 stale 상태 유지
   - 서버 재시작 시 DB 기준 lazy-init → 재고가 실제보다 많게 복원됨

2. 결제 취소 시 재고 복원 누락
   - PaymentServiceImpl.cancelPayment() fullCancel 분기에서
     order.cancel()만 호출하고 Redis INCRBY 미실행
   - 결제 취소 후 재고가 영구적으로 Redis에서 복원되지 않는 버그

## 시도 1 — 실패: 동기 AFTER_COMMIT + REQUIRES_NEW

@TransactionalEventListener(AFTER_COMMIT) + @transactional(REQUIRES_NEW) 동기 실행 시도

Spring commit 순서:
  1. doCommit()               → DB COMMIT 전송
  2. triggerAfterCommit()     → AFTER_COMMIT 리스너 실행  ← 원래 커넥션 아직 미반환
  3. cleanupAfterCompletion() → 커넥션 반환

AFTER_COMMIT 안에서 REQUIRES_NEW가 두 번째 커넥션을 요청하는 순간
원래 커넥션은 아직 풀에 반환되지 않은 상태.
120 VU × 2 커넥션 = 240개 필요, HikariCP 풀 size = 30 → 완전 교착

결과:
  create p95 = 58,300ms / error rate = 14.8% / timeout 대량 발생

## 시도 2 — 성공: https://github.com/async + AFTER_COMMIT + REQUIRES_NEW

https://github.com/async("stockSyncExecutor") 추가.
요청 스레드는 이벤트를 큐에 넣고 즉시 반환(커넥션 반환),
stockSyncExecutor 스레드풀의 별도 스레드가 새 커넥션을 획득해 DB sync 처리.
AFTER_ROLLBACK은 동기 유지 — Redis 보상은 즉각적이어야 하므로.

## 변경 내용

- StockDeltaEvent: DECREASE/INCREASE 타입 이벤트 레코드 신규 추가
- StockSyncEventListener: AFTER_COMMIT(DB sync) + AFTER_ROLLBACK(Redis 보상) 리스너 신규 추가
- OrderServiceImpl: reserveStock(), restoreStock()에 이벤트 발행 추가
- PaymentServiceImpl: fullCancel 시 stockCacheService.restore() + 이벤트 발행 추가
- AsyncConfig: stockSyncExecutor 스레드풀 추가 (core=5, max=10, queue=200)
- OrderServiceTest / PaymentServiceTest: ApplicationEventPublisher, StockCacheService Mock 추가

## 성능 테스트 결과 (120 VU, 단일 SKU 집중)

| 지표                   | :6 (Redis, sync 없음) | :7 (동기 AFTER_COMMIT) | :8 (비동기 AFTER_COMMIT) |
|------------------------|-----------------------|------------------------|--------------------------|
| create p95             | 1,090ms               | 58,300ms               | 552ms                    |
| error rate             | 0%                    | 14.8%                  | 0%                       |
| http p99               | -                     | -                      | 761ms                    |
| HikariCP Pending       | ~0                    | 폭증                   | 0                        |
| DB stock_quantity sync | X                     | X                      | O                        |

## 최종 목표 달성 현황

| 목표                     | 결과                  |
|--------------------------|-----------------------|
| order_create p95 < 800ms | 552ms (달성)          |
| http p99 < 1,000ms       | 761ms (달성)          |
| error rate < 5%          | 0% (달성)             |
| http p95 < 500ms         | 513ms (13ms 초과)     |

## 향후 과제

1. DB sync 멱등성
   - Spring 인메모리 이벤트 → 서버 재시작 시 이벤트 유실 가능
   - reconciliation 스케줄러(Redis ↔ DB 주기적 비교) 추가 필요

2. Redis SPOF
   - Redis 다운 시 전체 주문 실패 (fallback 없음)
   - Circuit Breaker 또는 DB fallback 추가 필요

3. http p95 513ms
   - 목표 500ms 대비 13ms 초과
   - order_create(291ms avg) 추가 튜닝 여지 있음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced event-driven stock synchronization that automatically keeps cache and database in sync with error recovery.
  * Enhanced order cancellation to immediately restore inventory to available stock.

* **Chores**
  * Updated backend service to latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->